### PR TITLE
[feat]: iconbutton 컴포넌트 작성 #11

### DIFF
--- a/src/components/ui/iconButton.tsx
+++ b/src/components/ui/iconButton.tsx
@@ -1,0 +1,160 @@
+import { Slot } from '@radix-ui/react-slot';
+import { Download, Layers2, Layers3, RefreshCw, RotateCcw, Save, Upload } from 'lucide-react';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface IconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  icon: React.ReactNode;
+  label: string;
+  asChild?: boolean;
+  iconBgColor?: string;
+  iconColor?: string;
+  width?: string;
+}
+
+const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
+  (
+    {
+      icon,
+      label,
+      asChild = false,
+      iconBgColor = 'bg-gray-100',
+      iconColor = 'text-black',
+      width = '228px',
+      className,
+      ...props
+    },
+    ref
+  ) => {
+    const Comp = asChild ? Slot : 'button';
+
+    return (
+      <Comp
+        ref={ref}
+        className={cn(
+          'inline-flex items-center justify-center text-sm font-medium transition-colors',
+          'hover:bg-gray-100',
+          'bg-gray-50',
+          className
+        )}
+        aria-label={label}
+        {...props}
+        style={{
+          display: 'flex',
+          width,
+          padding: '8px 10px',
+          alignItems: 'center',
+          gap: '8px',
+          borderRadius: '8px',
+        }}
+      >
+        <span
+          className={cn(iconBgColor, iconColor, 'flex items-center justify-center')}
+          style={{
+            width: '20px',
+            height: '20px',
+            borderRadius: '5px',
+          }}
+        >
+          {React.cloneElement(icon as React.ReactElement, { width: 13, height: 13 })}
+        </span>
+        <span
+          style={{
+            color: 'var(--Text-primary, #1B1B1B)',
+            fontFamily: 'Pretendard',
+            fontSize: '16px',
+            fontWeight: 400,
+            lineHeight: '24px',
+          }}
+        >
+          {label}
+        </span>
+      </Comp>
+    );
+  }
+);
+IconButton.displayName = 'IconButton';
+
+export function UploadButton() {
+  return (
+    <IconButton
+      icon={<Upload />}
+      label="텍스트 파일 업로드"
+      iconBgColor="bg-purple-100"
+      iconColor="text-purple-500"
+      width="167px"
+    />
+  );
+}
+
+export function SaveButton() {
+  return (
+    <IconButton
+      icon={<Save />}
+      label="저장"
+      iconBgColor="bg-pink-50"
+      iconColor="text-pink-500"
+      width="76px"
+    />
+  );
+}
+
+export function RecreateButton() {
+  return (
+    <IconButton
+      icon={<RefreshCw />}
+      label="재생성"
+      iconBgColor="bg-blue-50"
+      iconColor="text-blue-600"
+      width="90px"
+    />
+  );
+}
+
+export function DownloadButton() {
+  return (
+    <IconButton
+      icon={<Download />}
+      label="다운로드"
+      iconBgColor="bg-blue-50"
+      iconColor="text-blue-600"
+      width="104px"
+    />
+  );
+}
+
+export function ApplySelectionButton() {
+  return (
+    <IconButton
+      icon={<Layers2 />}
+      label="선택 적용"
+      iconBgColor="bg-blue-50"
+      iconColor="text-blue-600"
+    />
+  );
+}
+
+export function ApplyAllButton() {
+  return (
+    <IconButton
+      icon={<Layers3 />}
+      label="전체 적용"
+      iconBgColor="bg-blue-50"
+      iconColor="text-blue-600"
+    />
+  );
+}
+
+export function ResetChangesButton() {
+  return (
+    <IconButton
+      icon={<RotateCcw />}
+      label="변경 초기화"
+      iconBgColor="bg-blue-50"
+      iconColor="text-blue-600"
+    />
+  );
+}
+
+export { IconButton };


### PR DESCRIPTION
iconbutton 7종 작성 
closes #11 

          <UploadButton />
          <DownloadButton />
          <RecreateButton />
          <SaveButton />
          <ApplySelectionButton />
          <ApplyAllButton />
          <ResetChangesButton />

<img width="242" alt="스크린샷 2024-11-06 오전 10 20 41" src="https://github.com/user-attachments/assets/b7f0d5bd-1288-4a49-85ab-af48dcccb420">

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- 수정된 화면이나 기능을 보여주는 스크린샷을 첨부할 수 있습니다. -->

## Sourcery에 의한 요약

새로운 기능:
- 일곱 개의 새로운 아이콘 버튼 컴포넌트 도입: UploadButton, DownloadButton, RecreateButton, SaveButton, ApplySelectionButton, ApplyAllButton, 그리고 ResetChangesButton.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce seven new icon button components: UploadButton, DownloadButton, RecreateButton, SaveButton, ApplySelectionButton, ApplyAllButton, and ResetChangesButton.

</details>