### PR TITLE
feat: commonButton 컨포넌트 #22

### DIFF
--- a/src/components/ui/commonbutton.tsx
+++ b/src/components/ui/commonbutton.tsx
@@ -1,0 +1,101 @@
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+// 아이콘 컴포넌트 정의
+const PlusIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    className="flex-shrink-0"
+  >
+    <path
+      d="M2 12C2 7.28595 2 4.92893 3.46447 3.46447C4.92893 2 7.28595 2 12 2C16.714 2 19.0711 2 20.5355 3.46447C22 4.92893 22 7.28595 22 12C22 16.714 22 19.0711 20.5355 20.5355C19.0711 22 16.714 22 12 22C7.28595 22 4.92893 22 3.46447 20.5355C2 19.0711 2 16.714 2 12Z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M15 12L12 12M12 12L9 12M12 12L12 9M12 12L12 15"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+  </svg>
+);
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none font-pretendard text-lg leading-5',
+  {
+    variants: {
+      variant: {
+        default:
+          'bg-[#3A74FE] text-[color:var(--White,var(--Color,#FFF))] font-semibold hover:bg-[#356AE7] active:bg-[#2952B4] disabled:opacity-40 disabled:bg-[#3A74FE]',
+        secondary: [
+          'border border-[#C4C4C4] rounded-lg font-medium',
+          'bg-[var(--Color,#FFF)] text-[#5C5C5C]',
+          'hover:bg-[#F7F7F7] hover:text-[#1B1B1B]',
+          'active:bg-[#E4E4E4] active:text-[#1B1B1B]',
+          'disabled:bg-[var(--Color,#FFF)] disabled:text-[#C4C4C4] disabled:cursor-not-allowed',
+        ],
+      },
+      size: {
+        default: 'h-14 w-[360px] flex-shrink-0 rounded-lg',
+        mid: 'w-[196px] px-[19px] py-3 gap-2.5 rounded-lg',
+        icon: 'w-14 h-14 p-4 flex-shrink-0 rounded-lg',
+      },
+      hasIcon: {
+        true: 'inline-flex items-center',
+        false: '',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+      hasIcon: false,
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+  icon?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, icon = false, children, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+
+    const content =
+      size === 'icon' ? (
+        <PlusIcon />
+      ) : (
+        <>
+          {icon && <PlusIcon />}
+          {children}
+        </>
+      );
+
+    return (
+      <Comp
+        className={cn(
+          buttonVariants({ variant, size, hasIcon: icon || size === 'icon', className })
+        )}
+        ref={ref}
+        {...props}
+      >
+        {content}
+      </Comp>
+    );
+  }
+);
+
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,7 +1,34 @@
+import { Button } from '@/components/ui/commonbutton';
 const LoginPage = () => {
   return (
     <div>
       <h1>LoginPage</h1>
+      <div>
+        <div>default</div>
+        <Button>Button</Button>
+        <Button disabled>Button</Button>
+      </div>
+      <div>
+        <div>mid + icon</div>
+        <Button size="mid" icon>
+          Button
+        </Button>
+        <Button size="mid" icon disabled>
+          Button
+        </Button>
+      </div>
+      <div>
+        <div>icon</div>
+        <Button size="icon" />
+        <Button size="icon" disabled />
+      </div>
+      <div>
+        <div>Secondary - Grey</div>
+        <Button variant="secondary">Button</Button>
+        <Button variant="secondary" disabled>
+          Button
+        </Button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
<!-- 주요 변경 사항을 요약해 주세요. -->
CommonButton 컨포넌트
<!-- 수정된 화면이나 기능을 보여주는 스크린샷을 첨부할 수 있습니다. -->
![image](https://github.com/user-attachments/assets/a5941748-7481-4921-b78d-2384bce1615a)

사용법
        
        import { Button } from '@/components/ui/commonbutton';
        
        //default
        <Button>Button</Button>
        <Button disabled>Button</Button>

        //mid + icon
        <Button size="mid" icon>
          Button
        </Button>
        <Button size="mid" icon disabled>
          Button
        </Button>

        //icon
        <Button size="icon" />
        <Button size="icon" disabled />

        //Secondary - Grey
        <Button variant="secondary">Button</Button>
        <Button variant="secondary" disabled>
          Button
        </Button>

## Sourcery에 의한 요약

여러 가지 변형이 있는 새로운 CommonButton 컴포넌트를 추가하고 LoginPage에 통합하여 사용법을 보여줍니다.

새로운 기능:
- 기본, 아이콘이 있는 중간, 아이콘 전용, 보조 변형을 포함한 다양한 스타일과 크기의 새로운 CommonButton 컴포넌트를 도입합니다.

개선 사항:
- 새로운 CommonButton 컴포넌트를 통합하여 LoginPage를 개선하고, 다양한 스타일과 상태로 사용되는 방법을 보여줍니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new CommonButton component with multiple variants and integrate it into the LoginPage to showcase its usage.

New Features:
- Introduce a new CommonButton component with various styles and sizes, including default, mid with icon, icon-only, and secondary variants.

Enhancements:
- Enhance the LoginPage by integrating the new CommonButton component to demonstrate its usage with different styles and states.

</details>