### PR TITLE
[feat] TTS탭 레이아웃, 전체페이지 여백 변경 #42

### DIFF
--- a/src/components/layouts/NavbarLayout.tsx
+++ b/src/components/layouts/NavbarLayout.tsx
@@ -4,14 +4,14 @@ import { NavSidebar } from '../NavSidebar';
 
 const NavbarLayout = () => {
   return (
-    <>
-      <div className="flex min-h-screen bg-gray-50">
+    <div className="flex justify-center bg-white min-h-screen">
+      <div className="flex w-full max-w-[1440px]">
         <NavSidebar />
-        <main className="flex-1 p-3">
+        <main className="flex-1">
           <Outlet />
         </main>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/pages/TTSPage.tsx
+++ b/src/pages/TTSPage.tsx
@@ -1,7 +1,33 @@
 const TTSPage = () => {
   return (
-    <div>
-      <h1>TTSPage</h1>
+    <div className="max-w-[1200px] mx-auto flex flex-col min-h-screen">
+      {/* Header */}
+      <header className="bg-gray-200 h-[92px]">
+        <h1>My work status</h1>
+      </header>
+
+      <div className="flex flex-1">
+        {/* Main Content Group */}
+        <div className="flex-1 flex flex-col">
+          {/* Main1 */}
+          <section className="flex-1 ">
+            <h2>Main Content 1</h2>
+            {/* 메인1 콘텐츠 */}
+          </section>
+
+          {/* Main2 */}
+          <section className=" bg-gray-200 h-[135px]">
+            <h2>Main Content 2</h2>
+            {/* 메인2 콘텐츠 */}
+          </section>
+        </div>
+
+        {/* Right Sidebar */}
+        <aside className="w-[276px] bg-gray-100 flex-shrink-0 min-h-full">
+          <h2>TTS 옵션 설정</h2>
+          {/* 오른쪽 사이드바 콘텐츠 */}
+        </aside>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
- TTS 탭 레이아웃 적용
- 왼쪽에 붙어있던 네비바를 여백에 따른 가운데 정렬로 변경

TTSPage 배경색, 글씨 지우고 페이지 퍼블리싱 할 것.

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- 수정된 화면이나 기능을 보여주는 스크린샷을 첨부할 수 있습니다. -->
<img width="1432" alt="스크린샷 2024-11-07 오후 3 42 41" src="https://github.com/user-attachments/assets/49fbe7b3-46fb-4bd9-b3ea-e341029b32f7">

## Sourcery에 의한 요약

TTS 탭에 대한 새로운 레이아웃을 구현하여 헤더, 주요 콘텐츠 섹션 및 오른쪽 사이드바를 포함합니다. 네비게이션 바를 중앙에 배치하여 전체 페이지 정렬을 개선하기 위해 NavbarLayout을 조정합니다.

새로운 기능:
- 구조화된 헤더, 주요 콘텐츠 섹션 및 TTS 옵션을 위한 오른쪽 사이드바가 있는 TTS 탭에 대한 새로운 레이아웃을 도입합니다.

개선 사항:
- 페이지의 너비에 맞춰 네비게이션 바를 중앙에 배치하여 보다 균형 잡힌 레이아웃을 제공하도록 NavbarLayout을 수정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a new layout for the TTS tab, including a header, main content sections, and a right sidebar. Adjust the NavbarLayout to center the navigation bar, enhancing the overall page alignment.

New Features:
- Introduce a new layout for the TTS tab with a structured header, main content sections, and a right sidebar for TTS options.

Enhancements:
- Modify the NavbarLayout to center the navigation bar with respect to the page's width, providing a more balanced layout.

</details>