### PR TITLE
[fix] 타입 오류 수정, tsconfig파일 수정 #59

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "postcss": "^8.4.47",
         "prettier": "3.3.3",
         "tailwindcss": "^3.4.14",
-        "typescript": "~5.6.2",
+        "typescript": "5.3.2",
         "typescript-eslint": "^8.10.0",
         "vite": "^5.4.9"
       }
@@ -6451,9 +6451,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -p tsconfig.app.json && vite build",
     "lint": "eslint . --fix",
     "type-check": "tsc --noEmit -p tsconfig.app.json --incremental",
     "preview": "vite preview",

--- a/src/components/tts/TTSOptionsSidebar.tsx
+++ b/src/components/tts/TTSOptionsSidebar.tsx
@@ -4,7 +4,7 @@ import {
   ApplyAllButton,
   ApplySelectionButton,
   ResetChangesButton,
-} from '@/components/ui/iconButton';
+} from '@/components/ui/IconButton';
 import {
   Select,
   SelectContent,
@@ -12,7 +12,7 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/components/ui/select';
+} from '@/components/ui/Select';
 import { StateController } from '@/components/ui/StateController';
 
 const TTSOptionsSidebar: React.FC = () => {

--- a/src/pages/ExamplePage.tsx
+++ b/src/pages/ExamplePage.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@/components/ui/commonbutton';
+import { Button } from '@/components/ui/CommonButton';
 import Tooltip from '@/components/ui/tooltip';
 
 const ExamplePage = () => {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -19,7 +19,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
 
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
- #59
- 타입 오류가 난 부분들을 수정했습니다.
- "noUncheckedSideEffectImports" 옵션을 삭제했습니다. 현재 버전 타입스크립트에서는 해당 옵션이 없습니다. 
<!-- 수정된 화면이나 기능을 보여주는 스크린샷을 첨부할 수 있습니다. -->

## Sourcery에 의한 요약

타입 오류를 수정하고 더 이상 사용되지 않는 'noUncheckedSideEffectImports' 옵션을 제거하고 import 경로를 조정하여 TypeScript 구성을 업데이트합니다.

버그 수정:
- import 경로를 수정하여 코드베이스의 타입 오류를 수정합니다.

빌드:
- TypeScript 컴파일을 위해 package.json의 빌드 스크립트를 tsconfig.app.json을 사용하도록 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix type errors and update TypeScript configuration by removing the deprecated 'noUncheckedSideEffectImports' option and adjusting import paths.

Bug Fixes:
- Fix type errors in the codebase by correcting import paths.

Build:
- Update the build script in package.json to use tsconfig.app.json for TypeScript compilation.

</details>