### PR TITLE
[feat] audio histroy 작성 #145

### DIFF
--- a/src/components/audio/AudioHistoryDialog.tsx
+++ b/src/components/audio/AudioHistoryDialog.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { TbTrash, TbX } from 'react-icons/tb';
+
+import { AudioPlayer } from '@/components/audio/AudioPlayer';
+import { Checkbox } from '@/components/ui/checkbox';
+import { DialogClose, DialogContent, DialogPortal } from '@/components/ui/dialog';
+
+const AudioHistoryDialog = () => {
+  const [selectedItems, setSelectedItems] = React.useState<number[]>([]);
+  const audioHistory = [
+    { id: 1, time: '오늘 오전 11:30' },
+    { id: 2, time: '오늘 오전 09:30' },
+    { id: 3, time: '어제 오후 11:30' },
+    { id: 4, time: '어제 오후 11:20' },
+    { id: 5, time: '금요일 오전 11:30' },
+  ];
+
+  const handleSelectAll = (checked: boolean) => {
+    if (checked) {
+      setSelectedItems(audioHistory.map((audio) => audio.id));
+    } else {
+      setSelectedItems([]);
+    }
+  };
+
+  const handleSelectItem = (id: number, checked: boolean) => {
+    setSelectedItems((prev) => (checked ? [...prev, id] : prev.filter((itemId) => itemId !== id)));
+  };
+
+  const handleDelete = () => {
+    console.log('삭제된 아이템:', selectedItems);
+    // 삭제 로직 추가
+  };
+
+  const isAllSelected = selectedItems.length === audioHistory.length;
+
+  return (
+    <DialogPortal>
+      <DialogContent className="p-0 w-[789px]">
+        {/* Header */}
+        <div className="flex items-center p-6 border-b gap-3">
+          <h2 className="text-body1 pl-9">전체 음성 생성 내역</h2>
+          <span className="text-body1 text-gray-700">{audioHistory.length}</span>
+        </div>
+
+        {/* Toolbar */}
+        <div className="flex items-center px-6 py-2 gap-3 border-b">
+          <Checkbox
+            checked={isAllSelected}
+            onCheckedChange={(checked) => handleSelectAll(checked as boolean)}
+          />
+          <div
+            onClick={handleDelete}
+            className="flex items-center gap-1 px-2 py-1 text-gray-700 hover:cursor-pointer"
+          >
+            <TbTrash className="w-5 h-5" />
+            <span className="text-body2">삭제</span>
+          </div>
+        </div>
+
+        {/* History List */}
+        <div className="p-6 space-y-8">
+          {audioHistory.map((audio) => (
+            <div key={audio.id} className="flex items-center gap-3">
+              <Checkbox
+                checked={selectedItems.includes(audio.id)}
+                onCheckedChange={(checked) => handleSelectItem(audio.id, checked as boolean)}
+              />
+              <div className="flex flex-col gap-1 ">
+                {/* AudioPlayer Component */}
+                <AudioPlayer audioUrl="" className="w-[705px]" />
+                {/* Additional Info */}
+                <div className="flex justify-between text-body4 text-gray-300">
+                  <span>{audio.time}</span>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+        <DialogClose asChild>
+          <button
+            className="absolute right-6 top-6 flex items-center justify-center"
+            aria-label="Close"
+          >
+            <TbX className="w-6 h-6" />
+          </button>
+        </DialogClose>
+      </DialogContent>
+    </DialogPortal>
+  );
+};
+
+export default AudioHistoryDialog;

--- a/src/components/footer/AudioFooter.tsx
+++ b/src/components/footer/AudioFooter.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { TbHistory } from 'react-icons/tb';
 
+import AudioHistoryDialog from '@/components/audio/AudioHistoryDialog';
 import { AudioPlayer } from '@/components/audio/AudioPlayer';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
+import { Dialog, DialogTrigger } from '@/components/ui/dialog';
 import { Separator } from '@/components/ui/separator';
 import Jennie from '@/images/avatar/jennie.png';
 import { cn } from '@/lib/utils';
@@ -40,12 +42,20 @@ const AudioFooter = React.forwardRef<HTMLDivElement, AudioFooterProps>(
 
         <Separator orientation="vertical" className="flex-shrink-0 h-[56px] mr-4" />
 
-        <button
-          className="flex-shrink-0 p-2 hover:bg-gray-100 rounded-full transition-colors"
-          aria-label="History"
-        >
-          <TbHistory className="w-7 h-7 text-black" />
-        </button>
+        {/* Dialog Trigger */}
+        <Dialog>
+          <DialogTrigger asChild>
+            <button
+              className="flex-shrink-0 p-2 hover:bg-gray-100 rounded-full transition-colors"
+              aria-label="History"
+            >
+              <TbHistory className="w-7 h-7 text-black" />
+            </button>
+          </DialogTrigger>
+
+          {/* Dialog Content */}
+          <AudioHistoryDialog />
+        </Dialog>
       </div>
     );
   }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,6 +1,5 @@
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import * as React from 'react';
-import { TbX } from 'react-icons/tb';
 
 import { cn } from '@/lib/utils';
 
@@ -36,16 +35,12 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid w-full translate-x-[-50%] translate-y-[-50%] bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100 focus:outline-none disabled:pointer-events-none">
-        <TbX className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
 ));


### PR DESCRIPTION
- AudioHistoryDialog.tsx 작성
- 가운데에 위치

<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- 수정된 화면이나 기능을 보여주는 스크린샷을 첨부할 수 있습니다. -->
<img width="1318" alt="스크린샷 2024-11-22 오전 12 32 06" src="https://github.com/user-attachments/assets/f449a006-ac79-4b1b-bb24-81461d720d26">

## Sourcery에 의한 요약

오디오 기록을 관리하고 표시하기 위한 AudioHistoryDialog 컴포넌트를 추가하고, 사용자 상호작용을 위해 AudioFooter에 통합합니다.

새로운 기능:
- 오디오 기록 항목 목록을 표시하고 선택 및 삭제할 수 있는 옵션을 제공하는 AudioHistoryDialog 컴포넌트를 도입합니다.

개선 사항:
- AudioHistoryDialog를 AudioFooter 컴포넌트에 통합하여 사용자가 대화형 인터페이스를 통해 오디오 기록에 접근할 수 있도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an AudioHistoryDialog component to manage and display audio history, and integrate it into the AudioFooter for user interaction.

New Features:
- Introduce an AudioHistoryDialog component to display a list of audio history items with options to select and delete them.

Enhancements:
- Integrate the AudioHistoryDialog into the AudioFooter component, allowing users to access audio history through a dialog interface.

</details>