### PR TITLE
[feat] TTSidebar 수정(값들이 선택 되지 않았을 때 버튼 클릭 막기)

### DIFF
--- a/src/components/custom/buttons/IconButton.tsx
+++ b/src/components/custom/buttons/IconButton.tsx
@@ -181,8 +181,13 @@ export function TTSPlaybackHistoryButton({ onClick, isActive }: TTSPlaybackHisto
     />
   );
 }
-
-export function ApplySelectionButton({ onClick }: { readonly onClick?: () => void }) {
+export function ApplySelectionButton({
+  onClick,
+  isActive,
+}: {
+  readonly onClick?: () => void;
+  readonly isActive: boolean;
+}) {
   return (
     <IconButton
       icon={<TbStack />}
@@ -190,11 +195,18 @@ export function ApplySelectionButton({ onClick }: { readonly onClick?: () => voi
       iconBgColor="bg-blue-50"
       iconColor="text-blue-600"
       onClick={onClick}
+      className={isActive ? '' : `pointer-events-none opacity-50 cursor-not-allowed`}
     />
   );
 }
 
-export function ApplyAllButton({ onClick }: { readonly onClick?: () => void }) {
+export function ApplyAllButton({
+  onClick,
+  isActive,
+}: {
+  readonly onClick?: () => void;
+  readonly isActive: boolean;
+}) {
   return (
     <IconButton
       icon={<TbStack2 />}
@@ -202,11 +214,18 @@ export function ApplyAllButton({ onClick }: { readonly onClick?: () => void }) {
       iconBgColor="bg-blue-50"
       iconColor="text-blue-600"
       onClick={onClick}
+      className={isActive ? '' : `pointer-events-none opacity-50 cursor-not-allowed`}
     />
   );
 }
 
-export function ResetChangesButton({ onClick }: { readonly onClick?: () => void }) {
+export function ResetChangesButton({
+  onClick,
+  isActive,
+}: {
+  readonly onClick?: () => void;
+  readonly isActive: boolean;
+}) {
   return (
     <IconButton
       icon={<TbRefresh />}
@@ -214,6 +233,7 @@ export function ResetChangesButton({ onClick }: { readonly onClick?: () => void 
       iconBgColor="bg-blue-50"
       iconColor="text-blue-600"
       onClick={onClick}
+      className={isActive ? '' : `pointer-events-none opacity-50 cursor-not-allowed`}
     />
   );
 }

--- a/src/components/custom/buttons/IconButton.tsx
+++ b/src/components/custom/buttons/IconButton.tsx
@@ -186,7 +186,7 @@ export function ApplySelectionButton({
   isActive,
 }: {
   readonly onClick?: () => void;
-  readonly isActive: boolean;
+  readonly isActive?: boolean;
 }) {
   return (
     <IconButton
@@ -205,7 +205,7 @@ export function ApplyAllButton({
   isActive,
 }: {
   readonly onClick?: () => void;
-  readonly isActive: boolean;
+  readonly isActive?: boolean;
 }) {
   return (
     <IconButton
@@ -224,7 +224,7 @@ export function ResetChangesButton({
   isActive,
 }: {
   readonly onClick?: () => void;
-  readonly isActive: boolean;
+  readonly isActive?: boolean;
 }) {
   return (
     <IconButton

--- a/src/components/section/sidebar/TTSSidebar.tsx
+++ b/src/components/section/sidebar/TTSSidebar.tsx
@@ -109,9 +109,9 @@ const TTSSidebar: React.FC = () => {
   const [speed, setSpeed] = useState(1.0);
   const [volume, setVolume] = useState(60);
   const [pitch, setPitch] = useState(4.0);
-  const [selectedLanguage, setSelectedLanguage] = useState(languageOptions[0].value);
-  const [selectedVoice, setSelectedVoice] = useState(voiceOptions[0].value);
-  const [selectedStyle, setSelectedStyle] = useState(styleOptions[0].value);
+  const [selectedLanguage, setSelectedLanguage] = useState('');
+  const [selectedVoice, setSelectedVoice] = useState('');
+  const [selectedStyle, setSelectedStyle] = useState('');
 
   return (
     <aside className="w-[276px] min-h-full border-l p-6">
@@ -128,6 +128,7 @@ const TTSSidebar: React.FC = () => {
           onValueChange={setSelectedLanguage}
           items={languageOptions}
           icon={<TbWorld className="h-5 w-5" />}
+          placeholder="-"
         />
       </div>
 
@@ -140,6 +141,7 @@ const TTSSidebar: React.FC = () => {
           onValueChange={setSelectedVoice}
           items={voiceOptions}
           icon={voiceOptions.find((voice) => voice.value === selectedVoice)?.icon || null}
+          placeholder="-"
         />
       </div>
 
@@ -153,6 +155,7 @@ const TTSSidebar: React.FC = () => {
           value={selectedStyle}
           onValueChange={setSelectedStyle}
           items={styleOptions}
+          placeholder="-"
         />
       </div>
 

--- a/src/components/section/sidebar/TTSSidebar.tsx
+++ b/src/components/section/sidebar/TTSSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { TbWorld } from 'react-icons/tb';
 
 import {
@@ -106,12 +106,23 @@ const styleOptions: SelectItemType[] = [
 ];
 
 const TTSSidebar: React.FC = () => {
-  const [speed, setSpeed] = useState(1.0);
-  const [volume, setVolume] = useState(60);
-  const [pitch, setPitch] = useState(4.0);
+  const [speed, setSpeed] = useState(0);
+  const [volume, setVolume] = useState(0);
+  const [pitch, setPitch] = useState(0);
   const [selectedLanguage, setSelectedLanguage] = useState('');
   const [selectedVoice, setSelectedVoice] = useState('');
   const [selectedStyle, setSelectedStyle] = useState('');
+
+  const isActive = useMemo(() => {
+    return (
+      speed !== 0 &&
+      volume !== 0 &&
+      pitch !== 0 &&
+      selectedLanguage !== '' &&
+      selectedVoice !== '' &&
+      selectedStyle !== ''
+    );
+  }, [speed, volume, pitch, selectedLanguage, selectedVoice, selectedStyle]);
 
   return (
     <aside className="w-[276px] min-h-full border-l p-6">
@@ -203,19 +214,18 @@ const TTSSidebar: React.FC = () => {
       <div className="flex flex-col gap-4">
         <TooltipWrapper content={TTS_TOOLTIP.APPLY_SELECTED}>
           <div>
-            <ApplySelectionButton />
+            <ApplySelectionButton isActive={isActive} />
           </div>
         </TooltipWrapper>
 
         <TooltipWrapper content={TTS_TOOLTIP.APPLY_ALL}>
           <div>
-            <ApplyAllButton />
+            <ApplyAllButton isActive={isActive} />
           </div>
         </TooltipWrapper>
-
         <TooltipWrapper content={TTS_TOOLTIP.RESET_SETTINGS}>
           <div>
-            <ResetChangesButton />
+            <ResetChangesButton isActive={isActive} />
           </div>
         </TooltipWrapper>
       </div>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -15,17 +15,16 @@ interface SelectProps extends React.ComponentProps<typeof SelectPrimitive.Root> 
   items?: SelectItemType[];
   icon?: React.ReactNode;
   className?: string;
+  value?: string;
   id?: string;
 }
 
 const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
-  ({ placeholder, items = [], icon, className, id, ...props }, ref) => {
-    const defaultValue = items.length > 0 ? items[0].value : '';
-
+  ({ placeholder, items = [], icon, className, value, id, ...props }, ref) => {
     return (
-      <SelectPrimitive.Root {...props} defaultValue={defaultValue}>
-        <SelectTrigger id={id} ref={ref} icon={icon} className={className}>
-          <SelectValue placeholder={placeholder || items[0]?.label || 'Select...'} />
+      <SelectPrimitive.Root {...props}>
+        <SelectTrigger id={id} ref={ref} icon={value ? icon : ''} className={className}>
+          <SelectValue placeholder={placeholder || '-'} />
         </SelectTrigger>
         <SelectContent>
           {items.map((item) => (


### PR DESCRIPTION
- isActive 타입을 필수가 아닌 선택으로 변경
 - 언어, 목소리, 속도, 볼륨, 피치 등이 선택 되었을 때만 `tts 설정 적용 버튼들`이 활성화Active 되도록 변경
- 현재는 각 속도, 피치 볼륨등 값이 빈 문자열과 0으로 초기화 되어있습니다.
- #155

```jsx
  const [speed, setSpeed] = useState(0);
  const [volume, setVolume] = useState(0);
  const [pitch, setPitch] = useState(0);
  const [selectedLanguage, setSelectedLanguage] = useState('');
  const [selectedVoice, setSelectedVoice] = useState('');
  const [selectedStyle, setSelectedStyle] = useState(''); 

  const isActive = useMemo(() => {
    return (
      speed !== 0 &&
      volume !== 0 &&
      pitch !== 0 &&
      selectedLanguage !== '' &&
      selectedVoice !== '' &&
      selectedStyle !== ''
    );
  }, [speed, volume, pitch, selectedLanguage, selectedVoice, selectedStyle]);

```

## Sourcery에 의한 요약

개선 사항:
- TTSidebar 컴포넌트를 수정하여 언어, 음성, 속도, 볼륨 및 피치가 선택되지 않았을 때 버튼을 비활성화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Modify the TTSidebar component to disable buttons when language, voice, speed, volume, and pitch are not selected.

</details>