### PR TITLE
[fix] 프로젝트 id를 null로 받아서 계속 새로운 프로젝트로 인식하는 버그 수정 #200

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,13 +1,13 @@
-# addReviewers: true
+addReviewers: true
 
-# reviewers:
-#   - nakyeonko3
-#   - love1ace
-#   - ssumanlife
-#   - haruyam15
+reviewers:
+  - nakyeonko3
+  - sjgaru-dev
+  - miniseung 
+  - dyeongg 
 
 addAssignees: author
-# numberOfReviewers: 2
+numberOfReviewers: 0
 
 skipKeywords:
   - wip

--- a/src/api/ttsApi.ts
+++ b/src/api/ttsApi.ts
@@ -5,17 +5,14 @@ export const saveTTSProject = async (data: TTSSaveDto) => {
   try {
     console.log('보낸 데이터:', data);
 
-    // 응답은 이미 response.data만 반환
     const response = await customInstance.post('/tts/save', data);
+    console.log('서버 응답:', response.data);
 
-    console.log('서버 응답:', response);
-
-    // 성공 여부 확인
-    if (response.data?.success) {
+    if (response.data?.ttsProject) {
       console.log('TTS 프로젝트 저장 성공:', response.data);
-      return response.data;
+      return response.data; // 서버 응답 데이터 반환
     } else {
-      console.error('TTS 프로젝트 저장 실패:', response.data?.message || '응답 데이터 없음');
+      console.error('TTS 프로젝트 저장 실패: 응답 데이터 없음');
       return null;
     }
   } catch (error) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,6 @@
 import './index.css';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 
@@ -10,9 +9,7 @@ import { router } from './routes/router';
 const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>
-  </StrictMode>
+  <QueryClientProvider client={queryClient}>
+    <RouterProvider router={router} />
+  </QueryClientProvider>
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import './index.css';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 
@@ -9,7 +10,9 @@ import { router } from './routes/router';
 const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')!).render(
-  <QueryClientProvider client={queryClient}>
-    <RouterProvider router={router} />
-  </QueryClientProvider>
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  </StrictMode>
 );

--- a/src/pages/TTSPage.tsx
+++ b/src/pages/TTSPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { ttsLoad } from '@/api/aIParkAPI';
-import { TTSDetailDto, TTSSaveDto } from '@/api/aIParkAPI.schemas';
+import { TTSSaveDto } from '@/api/aIParkAPI.schemas';
 import { saveTTSProject } from '@/api/ttsApi';
 import { FileProgressItem } from '@/components/custom/dropdowns/FileProgressDropdown';
 import ProjectMainContents, {
@@ -92,20 +92,20 @@ const TTSPage = () => {
   // TTS 상태 로드
   const fetchTTSState = useCallback(async (id: number) => {
     try {
-      // ttsLoad 호출
       const response = await ttsLoad(id);
-
       if (response.data?.success && response.data.data) {
         const { ttsProject, ttsDetails } = response.data.data;
 
-        setProjectId(ttsProject.id); // 프로젝트 ID 설정
+        // projectId 업데이트
+        setProjectId(ttsProject.id);
+
         setProjectData((prev) => ({
           ...prev,
           projectId: ttsProject.id,
           projectName: ttsProject.projectName,
         }));
 
-        const loadedItems = ttsDetails.map((detail: TTSDetailDto) => ({
+        const loadedItems = ttsDetails.map((detail) => ({
           id: String(detail.id),
           text: detail.unitScript || '',
           isSelected: false,
@@ -114,8 +114,6 @@ const TTSPage = () => {
           pitch: detail.unitPitch || 1.0,
         }));
         setItems(loadedItems);
-      } else {
-        console.error('TTS 상태 로드 실패:', response.data?.message);
       }
     } catch (error) {
       console.error('TTS 상태 로드 중 오류:', error);
@@ -134,12 +132,16 @@ const TTSPage = () => {
       const response = await saveTTSProject({
         ...projectData, // 항상 최신 상태를 가져옴
       });
+
       if (response) {
         console.log('프로젝트 저장 성공:', response);
+
+        // 저장된 프로젝트 ID 업데이트
         setProjectData((prev) => ({
           ...prev,
-          projectId: response.data.ttsProject.id, // 서버 응답 데이터 반영
+          projectId: response.ttsProject.id,
         }));
+        console.log('업데이트된 projectId:', response.ttsProject.id);
       }
     } catch (error) {
       console.error('프로젝트 저장 오류:', error);


### PR DESCRIPTION
<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- 수정된 화면이나 기능을 보여주는 스크린샷을 첨부할 수 있습니다. -->
1. saveTTSProject 성공 후 반환된 projectId 업데이트
2. 초기 상태에서 projectId 유지

## Sourcery에 의한 요약

프로젝트 ID가 잘못 설정되어 null로 설정되는 버그를 수정하여 기존 프로젝트를 업데이트하는 대신 새로운 프로젝트가 생성되는 문제를 해결합니다. TTS 상태 로드 실패에 대한 불필요한 오류 로그를 제거하여 코드를 개선합니다.

버그 수정:
- 프로젝트 ID가 null로 설정되어 시스템이 매번 새로운 프로젝트로 인식하는 문제를 수정합니다.

개선 사항:
- 실패한 TTS 상태 로드에 대한 불필요한 오류 로그를 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the bug where the project ID was incorrectly set to null, leading to the creation of new projects instead of updating existing ones. Enhance the code by removing redundant error logging for TTS state load failures.

Bug Fixes:
- Fix the issue where the project ID was being set to null, causing the system to recognize it as a new project each time.

Enhancements:
- Remove unnecessary error logging for failed TTS state loads.

</details>