### PR TITLE
[feat] 히스토리 내역 페이지 퍼블리싱 #202

### DIFF
--- a/src/components/custom/tables/history/HistoryListTable.tsx
+++ b/src/components/custom/tables/history/HistoryListTable.tsx
@@ -1,0 +1,145 @@
+import { TbCircleFilled, TbDownload } from 'react-icons/tb';
+
+import { PlayButton } from '@/components/custom/buttons/PlayButton';
+import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+export interface ProjectListTableItem {
+  id: string;
+  order: string;
+  projectName: string;
+  fileName: string;
+  content: string;
+  type: 'VC' | 'TTS' | 'CONCAT';
+  status: '진행' | '대기중' | '실패' | '완료';
+  createdAt: string;
+}
+
+interface HistoryListTableProps {
+  items: ProjectListTableItem[];
+  onPlay: (id: string) => void;
+  onPause: (id: string) => void;
+  currentPlayingId?: string;
+  isAllSelected: boolean;
+  itemCount: number;
+  onSelectAll: (checked: boolean) => void;
+  selectedItems: string[];
+  onSelectionChange: (id: string, checked: boolean) => void;
+}
+
+const AudioBadge = ({ type }: { type: 'VC' | 'TTS' | 'CONCAT' }) => (
+  <Badge variant={type.toLowerCase() as 'vc' | 'tts' | 'concat'}>{type}</Badge>
+);
+
+const StatusBadge = (status: '진행' | '대기중' | '실패' | '완료') => {
+  const variantMap = {
+    진행: 'progress',
+    대기중: 'waiting',
+    실패: 'failed',
+    완료: 'completed',
+  } as const;
+
+  return (
+    <div className="flex justify-start">
+      <Badge variant={variantMap[status]}>
+        <TbCircleFilled className="w-2 h-2 mr-2" />
+        {status}
+      </Badge>
+    </div>
+  );
+};
+
+export function HistoryListTable({
+  items,
+  onPlay,
+  onPause,
+  currentPlayingId,
+  isAllSelected,
+  itemCount,
+  onSelectAll,
+  selectedItems,
+  onSelectionChange,
+}: HistoryListTableProps) {
+  return (
+    <Table className="table-fixed w-full">
+      {/* Header */}
+      <TableHeader className="bg-gray-50">
+        <TableRow>
+          <TableHead className="pl-6 w-[50px]">
+            <Checkbox
+              checked={itemCount > 0 && isAllSelected}
+              onCheckedChange={(checked) => onSelectAll(checked as boolean)}
+            />
+          </TableHead>
+          <TableHead className="pl-16 text-body3 text-black w-[130px]">유형</TableHead>
+          <TableHead className="text-body3 text-black w-[130px]">프로젝트명</TableHead>
+          <TableHead className="text-body3 text-black w-[100px]">파일명</TableHead>
+          <TableHead className="p-0 text-body3 text-black w-[300px]">내용</TableHead>
+          <TableHead className="text-body3 text-black w-[60px] text-center">상태</TableHead>
+          <TableHead className="text-body3 text-black w-[80px] text-center whitespace-nowrap">
+            다운로드
+          </TableHead>
+          <TableHead className="text-body3 text-black w-[130px]">업데이트 날짜</TableHead>
+        </TableRow>
+      </TableHeader>
+
+      {/* Body */}
+      <TableBody>
+        {items.map((item) => (
+          <TableRow
+            key={item.id}
+            data-state={currentPlayingId === item.id ? 'selected' : undefined}
+            className="text-body2"
+          >
+            <TableCell className="pl-6 w-[50px] ">
+              <Checkbox
+                checked={selectedItems.includes(item.id)}
+                onCheckedChange={(checked) => onSelectionChange(item.id, checked as boolean)}
+              />
+            </TableCell>
+            <TableCell className="w-[100px] text-left">
+              <div className="flex items-center gap-4">
+                <PlayButton
+                  isPlaying={currentPlayingId === item.id}
+                  onPlay={() => onPlay(item.id)}
+                  onPause={() => onPause(item.id)}
+                />
+                <AudioBadge type={item.type} />
+              </div>
+            </TableCell>
+
+            <TableCell className="whitespace-nowrap">{item.projectName}</TableCell>
+            <TableCell className="whitespace-nowrap">{item.fileName}</TableCell>
+            <TableCell className="max-w-md p-0">
+              <div className="whitespace-nowrap overflow-hidden text-ellipsis">{item.content}</div>
+            </TableCell>
+            <TableCell>
+              <div className="flex justify-center p-0 whitespace-nowrap">
+                {StatusBadge(item.status)}
+              </div>
+            </TableCell>
+            <TableCell>
+              <div className="flex items-center justify-center">
+                <button
+                  onClick={() => console.log('다운로드:', item.id)}
+                  aria-label="Download file"
+                >
+                  <TbDownload className="h-6 w-6" />
+                </button>
+              </div>
+            </TableCell>
+            <TableCell className="text-gray-700 whitespace-nowrap">{item.createdAt}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/components/section/sidebar/NavSidebar.tsx
+++ b/src/components/section/sidebar/NavSidebar.tsx
@@ -98,7 +98,7 @@ export function NavSidebar() {
           <div className="flex flex-col w-full gap-3">
             <SidebarButton icon={TbSmartHome} label="홈" />
             <SidebarButton icon={TbFolders} label={isExpanded ? '프로젝트 목록' : '프로젝트'} />
-            <SidebarButton icon={TbFolderShare} label={isExpanded ? '히스토리 목록' : '히스토리'} />
+            <SidebarButton icon={TbFolderShare} label={isExpanded ? '히스토리 내역' : '히스토리'} />
           </div>
         </div>
         <Separator className="my-4" />

--- a/src/pages/HistorysPage.tsx
+++ b/src/pages/HistorysPage.tsx
@@ -1,0 +1,154 @@
+import { useState } from 'react';
+
+import { HistoryListTable } from '@/components/custom/tables/history/HistoryListTable';
+import { ProjectListTableItem } from '@/components/custom/tables/history/ProjectListTable';
+import TableToolbar from '@/components/custom/tables/history/TableToolbar';
+import MainHeader from '@/components/section/header/MainHeader';
+import jisuImage from '@/images/avatar/jisu.jpg';
+import PageLayout from '@/layouts/PageLayout';
+
+const dummyData: ProjectListTableItem[] = [
+  {
+    id: '1',
+    order: '1',
+    projectName: '프로젝트1 발표자료',
+    fileName: '파일1.wav',
+    content: '안녕하세요. 프로젝트1에 대한 발표를 시작해 보겠습니다. 이프로젝트는말이요',
+    type: 'TTS',
+    status: '완료',
+    createdAt: '금요일 오후 7:24',
+  },
+  {
+    id: '2',
+    order: '2',
+    projectName: '프로젝트2 발표자료',
+    fileName: '파일2.wav',
+    content: '프로젝트2에 대해 간단히 설명드리겠습니다.',
+    type: 'CONCAT',
+    status: '진행',
+    createdAt: '금요일 오후 6:20',
+  },
+  {
+    id: '3',
+    order: '3',
+    projectName: '프로젝트3 자료',
+    fileName: '파일3.wav',
+    content: '이 자료는 프로젝트3에 관련된 것입니다.',
+    type: 'VC',
+    status: '실패',
+    createdAt: '금요일 오후 5:10',
+  },
+  {
+    id: '4',
+    order: '4',
+    projectName: '프로젝트4 요약자료',
+    fileName: '파일4.wav',
+    content: '프로젝트4 요약자료입니다.',
+    type: 'TTS',
+    status: '대기중',
+    createdAt: '금요일 오후 4:30',
+  },
+  {
+    id: '5',
+    order: '5',
+    projectName: '프로젝트5 발표자료',
+    fileName: '파일5.wav',
+    content: '프로젝트5에 대한 발표 자료입니다.',
+    type: 'CONCAT',
+    status: '완료',
+    createdAt: '금요일 오후 3:45',
+  },
+];
+
+const HistorysPage = () => {
+  const [selectedItems, setSelectedItems] = useState<string[]>([]); // 선택된 항목 관리
+  const [isAllSelected, setIsAllSelected] = useState(false); // 전체 선택 상태 관리
+
+  const handlePlay = (id: string) => {
+    console.log(`${id} 재생 시작`);
+  };
+
+  const handlePause = (id: string) => {
+    console.log(`${id} 재생 중지`);
+  };
+
+  const handleDelete = () => {
+    console.log('삭제:', selectedItems);
+  };
+
+  const handleSearch = (searchTerm: string) => {
+    console.log('검색어:', searchTerm);
+  };
+
+  const handleFilter = () => {
+    console.log('필터 버튼 클릭');
+  };
+
+  const handleSelectAll = (checked: boolean) => {
+    if (checked) {
+      setSelectedItems(dummyData.map((item) => item.id));
+      setIsAllSelected(true);
+    } else {
+      setSelectedItems([]);
+      setIsAllSelected(false);
+    }
+    console.log(`전체 선택 상태: ${checked ? '선택됨' : '해제됨'}`);
+  };
+
+  const handleSelectionChange = (id: string, checked: boolean) => {
+    if (checked) {
+      setSelectedItems((prev) => [...prev, id]);
+    } else {
+      setSelectedItems((prev) => prev.filter((itemId) => itemId !== id));
+    }
+  };
+
+  return (
+    <PageLayout
+      variant="main"
+      header={
+        <MainHeader
+          name="김바타"
+          email="aipark@aipark.ai"
+          imageUrl={jisuImage}
+          onMyPage={() => console.log('마이페이지 이동')}
+          onSignout={() => console.log('로그아웃')}
+        />
+      }
+    >
+      <div className="py-6">
+        <h2 className="text-h2 text-black mb-2">내보내기 내역</h2>
+        <p className="text-body2 text-black">
+          저장된 내보내기 기록을 조회하고 파일을 편리하게 다운로드할 수 있어요.
+        </p>
+      </div>
+      <div className="mt-2 border rounded-md">
+        {/* 컨트롤 패널 */}
+        <TableToolbar
+          title="모든 내보내기 내역"
+          count={dummyData.length}
+          selectedItemsCount={selectedItems.length}
+          onDelete={handleDelete}
+          onSearch={handleSearch}
+          onFilter={handleFilter}
+        />
+
+        {/* 테이블 */}
+        <div>
+          <HistoryListTable
+            onPlay={handlePlay}
+            onPause={handlePause}
+            itemCount={dummyData.length}
+            isAllSelected={isAllSelected}
+            onSelectAll={handleSelectAll}
+            selectedItems={selectedItems}
+            onSelectionChange={handleSelectionChange}
+            items={dummyData}
+          />
+        </div>
+      </div>
+    </PageLayout>
+  );
+};
+
+export default HistorysPage;

--- a/src/pages/HistorysPage.tsx
+++ b/src/pages/HistorysPage.tsx
@@ -117,15 +117,15 @@ const HistorysPage = () => {
       }
     >
       <div className="py-6">
-        <h2 className="text-h2 text-black mb-2">내보내기 내역</h2>
+        <h2 className="text-h2 text-black mb-2">히스토리 내역</h2>
         <p className="text-body2 text-black">
-          저장된 내보내기 기록을 조회하고 파일을 편리하게 다운로드할 수 있어요.
+          저장된 히스토리 기록을 조회하고 파일을 편리하게 다운로드할 수 있어요.
         </p>
       </div>
       <div className="mt-2 border rounded-md">
         {/* 컨트롤 패널 */}
         <TableToolbar
-          title="모든 내보내기 내역"
+          title="모든 히스토리 내역"
           count={dummyData.length}
           selectedItemsCount={selectedItems.length}
           onDelete={handleDelete}

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -4,6 +4,7 @@ import Layout from '@/layouts/Layout';
 import AccountRecoveryPage from '@/pages/AccountRecoveryPage';
 import CONCATPage from '@/pages/CONCATPage';
 import ErrorPage from '@/pages/ErrorPage';
+import HistorysPage from '@/pages/HistorysPage';
 import HomePage from '@/pages/HomePage';
 import MyPage from '@/pages/MyPage';
 import ProjectsPage from '@/pages/ProjectsPage';
@@ -17,6 +18,7 @@ const PATH = {
   SIGNIN: '/signin',
   SIGNUP: '/signup',
   PROJECTS: '/projects',
+  HISTORYS: '/Historys',
   ACCOUNT_RECOVERY_ID: '/find-id',
   ACCOUNT_RECOVERY_PW: '/find-pw',
   TTS: '/tts',
@@ -62,6 +64,10 @@ const router = createBrowserRouter([
       {
         path: PATH.PROJECTS,
         element: <ProjectsPage />,
+      },
+      {
+        path: PATH.HISTORYS,
+        element: <HistorysPage />,
       },
       {
         path: PATH.TTS,


### PR DESCRIPTION
<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- 수정된 화면이나 기능을 보여주는 스크린샷을 첨부할 수 있습니다. -->
<img width="1435" alt="스크린샷 2024-11-27 오후 4 44 54" src="https://github.com/user-attachments/assets/9b91ab27-f265-4e9c-8f0a-011e7b0491e1">

## Sourcery에 의한 요약

내보내기 기록을 볼 수 있는 새 페이지를 추가하고, 파일 재생, 일시 정지, 선택 및 다운로드 기능이 있는 테이블을 포함합니다. 이 새 페이지를 포함하도록 내비게이션을 업데이트합니다.

새로운 기능:
- 내보내기 기록을 표시하는 새로운 'HistorysPage' 컴포넌트를 도입하여 사용자가 저장된 기록 파일을 보고 다운로드할 수 있도록 합니다.

개선 사항:
- 내비게이션 사이드바를 업데이트하여 새로운 '히스토리 내역' 섹션을 포함합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new page for viewing export history records, including a table with functionalities for playing, pausing, selecting, and downloading files. Update the navigation to include this new page.

New Features:
- Introduce a new 'HistorysPage' component to display export history records, allowing users to view and download saved history files.

Enhancements:
- Update the navigation sidebar to include a new '히스토리 내역' (History Records) section.

</details>