### PR TITLE
[feat] 프로젝트탭 5개 제한, 새프로젝트생성 기본값 제거

### DIFF
--- a/src/components/custom/dialogs/CreateProjectDialog.tsx
+++ b/src/components/custom/dialogs/CreateProjectDialog.tsx
@@ -50,7 +50,7 @@ const features = [
 const CreateProjectDialogContent = () => {
   const navigate = useNavigate(); // useNavigate로 이동 기능 정의
   const addProject = useProjectStore((state) => state.addProject);
-  const [projectName, setProjectName] = useState('새 프로젝트');
+  const [projectName] = useState('새 프로젝트');
 
   // 프로젝트 생성 핸들러
   const handleNewProject = (type: 'TTS' | 'VC' | 'CONCAT', route: string) => {
@@ -58,19 +58,9 @@ const CreateProjectDialogContent = () => {
       name: projectName,
       type: type,
     });
-    const initialProjectData = {
-      projectId: null,
-      projectName: setProjectName('새 프로젝트'),
-      voiceStyleId: 9,
-      fullScript: '',
-      globalSpeed: 1.0,
-      globalPitch: 0.5,
-      globalVolume: 0.8,
-      ttsDetails: [],
-    };
 
-    // 선택한 경로로 초기 데이터를 전달하며 이동
-    navigate(route, { state: initialProjectData });
+    // 선택한 경로로 이동
+    navigate(route);
   };
 
   return (

--- a/src/components/custom/tables/history/RecentExportTable.tsx
+++ b/src/components/custom/tables/history/RecentExportTable.tsx
@@ -64,7 +64,7 @@ export function RecentExportTable({
       <div className="flex flex-col md:flex-row items-center justify-between mb-4">
         <h3 className="text-h3">최근 내보내기</h3>
         <p
-          onClick={() => navigate('/Historys')}
+          onClick={() => navigate('/History')}
           className="text-black text-body2 flex items-center gap-1 cursor-pointer"
         >
           전체보기

--- a/src/components/section/contents/RecontProject.tsx
+++ b/src/components/section/contents/RecontProject.tsx
@@ -83,7 +83,7 @@ const RecentProject = () => {
       <div className="flex flex-col md:flex-row items-center justify-between mb-4">
         <h3 className="text-h3">최근 프로젝트</h3>
         <p
-          onClick={() => navigate('/projects')}
+          onClick={() => navigate('/project')}
           className="text-black text-body2 flex items-center gap-1 cursor-pointer"
         >
           전체보기

--- a/src/components/section/sidebar/NavSidebar.tsx
+++ b/src/components/section/sidebar/NavSidebar.tsx
@@ -121,12 +121,12 @@ export function NavSidebar() {
             <SidebarButton
               icon={TbFolders}
               label={isExpanded ? '프로젝트 목록' : '프로젝트'}
-              onClick={() => navigate('/projects')}
+              onClick={() => navigate('/project')}
             />
             <SidebarButton
               icon={TbFolderShare}
               label={isExpanded ? '히스토리 내역' : '히스토리'}
-              onClick={() => navigate('/Historys')}
+              onClick={() => navigate('/History')}
             />
           </div>
         </div>
@@ -144,11 +144,11 @@ export function NavSidebar() {
           {/* <SidebarButton icon={TbFileTypography} label="TTS" />
           <SidebarButton icon={TbFileMusic} label="VC" />
           <SidebarButton icon={TbFileDatabase} label="CONCAT" /> */}
-          {projects.map((project) => (
+          {projects.slice(0, 5).map((project) => (
             <SidebarButton
               key={project.id}
               icon={getProjectIcon(project.type)}
-              label={project.name}
+              label={isExpanded ? `${project.type} ${project.name}` : project.type}
               onClick={() => navigate(`/${project.type.toLowerCase()}`)}
             />
           ))}


### PR DESCRIPTION
<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- 수정된 화면이나 기능을 보여주는 스크린샷을 첨부할 수 있습니다. -->

<img width="291" alt="스크린샷 2024-11-29 오전 11 04 10" src="https://github.com/user-attachments/assets/8165932e-2cd6-42d6-8218-4b42992d5e65">
<img width="222" alt="스크린샷 2024-11-29 오전 11 04 33" src="https://github.com/user-attachments/assets/050fdeea-e805-47f4-95e8-a550f0158638">


사이드바가 너무 길어지지 않기위해 5개로 제한

## Sourcery에 의한 요약

사이드바에 표시되는 프로젝트 수를 5개로 제한하고, 새 프로젝트를 생성할 때 기본 프로젝트 이름을 제거합니다. 일관성을 위해 탐색 경로를 업데이트합니다.

새로운 기능:
- 사이드바에 표시되는 프로젝트 수를 5개로 제한하여 과도한 길이를 방지합니다.

개선 사항:
- 새 프로젝트를 생성할 때 기본 프로젝트 이름을 제거하여 더 많은 유연성을 허용합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Limit the number of projects displayed in the sidebar to 5 and remove the default project name when creating a new project. Update navigation paths for consistency.

New Features:
- Limit the number of projects displayed in the sidebar to 5 to prevent excessive length.

Enhancements:
- Remove default project name when creating a new project to allow for more flexibility.

</details>