### PR TITLE
[feat] 로컬스토리지에 id만 저장하도록 변경 #233

### DIFF
--- a/src/components/custom/forms/SigninForm.tsx
+++ b/src/components/custom/forms/SigninForm.tsx
@@ -27,7 +27,7 @@ const SigninForm = () => {
         id: userData.data.id,
         email: userData.data.email,
         name: userData.data.name,
-        phoneNumber: userData.data.phone_number,
+        phoneNumber: userData.data.phoneNumber,
       });
 
       // 메인 페이지로 이동

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -3,15 +3,16 @@ import { persist } from 'zustand/middleware';
 
 interface User {
   id: number;
-  email: string;
-  name: string;
-  phoneNumber: string;
+  email?: string;
+  name?: string;
+  phoneNumber?: string;
 }
 
 interface AuthState {
   user: User | null;
   setUser: (user: User) => void;
   logout: () => void;
+  fetchUser: () => Promise<void>; // 서버에서 사용자 정보 가져오기
 }
 
 export const useAuthStore = create<AuthState>()(
@@ -20,10 +21,24 @@ export const useAuthStore = create<AuthState>()(
       user: null,
       setUser: (user) => set({ user }),
       logout: () => set({ user: null }),
+      fetchUser: async () => {
+        const id = JSON.parse(localStorage.getItem('auth-storage') || '{}').user?.id;
+        if (id) {
+          try {
+            const response = await fetch(`/api/user/${id}`);
+            const userData = await response.json();
+            set({ user: userData });
+          } catch (error) {
+            console.error('Failed to fetch user:', error);
+          }
+        }
+      },
     }),
     {
-      name: 'auth-storage', // localStorage 키 이름
-      partialize: (state) => ({ user: state.user }), // user 정보만 저장
+      name: 'auth-storage', // 로컬스토리지에 id만 저장
+      partialize: (state) => ({
+        user: state.user ? { id: state.user.id } : null, // id만 저장
+      }),
     }
   )
 );


### PR DESCRIPTION
<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- 수정된 화면이나 기능을 보여주는 스크린샷을 첨부할 수 있습니다. -->
<img width="1022" alt="스크린샷 2024-12-02 오후 4 41 57" src="https://github.com/user-attachments/assets/bdb40ad1-2c5d-4a5b-8de7-2a347f102342">
<img width="1124" alt="스크린샷 2024-12-02 오후 4 38 48" src="https://github.com/user-attachments/assets/9f27cab2-44c8-46a5-904b-36fddbf1d3a2">

기존에 유저 정보 다 저장하는 방식에서 유저 아이디만 저장 후 필요할때 세부 정보를 불러오도록 변경

## Sourcery에 의한 요약

인증 저장소를 수정하여 로컬 저장소에 사용자 ID만 저장하고 필요할 때 서버에서 전체 사용자 세부 정보를 가져오도록 합니다. 이 변경은 로컬 저장소 사용을 최적화하고 필요할 때 세부 정보를 검색하여 사용자 세부 정보가 최신 상태임을 보장합니다.

새로운 기능:
- 필요할 때 서버에서 사용자 세부 정보를 가져오는 메서드를 도입합니다.

개선 사항:
- 전체 사용자 세부 정보 대신 사용자 ID만 저장하도록 로컬 저장소 전략을 변경합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify the authentication store to store only the user ID in local storage and fetch full user details from the server when needed. This change optimizes local storage usage and ensures user details are up-to-date by retrieving them on demand.

New Features:
- Introduce a method to fetch user details from the server when needed.

Enhancements:
- Change the local storage strategy to store only the user ID instead of full user details.

</details>