### PR TITLE
[feat] 회원가입 구현 및 비밀번호 해쉬적용 

### DIFF
--- a/src/api/authAPI.ts
+++ b/src/api/authAPI.ts
@@ -2,6 +2,8 @@
 
 import { AxiosError } from 'axios';
 
+import { joaatHash } from '@/utils/joaatHash';
+
 import { customInstance } from './axios-client';
 
 interface SignupRequest {
@@ -12,10 +14,14 @@ interface SignupRequest {
   phoneNumber: string;
   terms: string;
 }
-export const login = async (email: string, pwd: string) => {
+export const login = async (email: string, pwd: string, isTemporaryPwd: boolean = false) => {
   try {
-    const data = await customInstance.post('/member/login', { email, pwd });
-    return data; // 명시적으로 반환
+    const password = isTemporaryPwd ? pwd : joaatHash(pwd);
+    const data = await customInstance.post('/member/login', {
+      email,
+      pwd: password,
+    });
+    return data;
   } catch (error: unknown) {
     if (error instanceof AxiosError) {
       const errorMessage =
@@ -39,7 +45,12 @@ export const logout = async () => {
 
 export const signup = async (signupRequest: SignupRequest) => {
   try {
-    const response = await customInstance.post('/member/signup', signupRequest);
+    const signupHashedPwd = {
+      ...signupRequest,
+      pwd: joaatHash(signupRequest.pwd),
+      pwdConfirm: joaatHash(signupRequest.pwdConfirm),
+    };
+    const response = await customInstance.post('/member/signup', signupHashedPwd);
     console.log('회원가입 서버 응답:', response);
     return response;
   } catch (error) {

--- a/src/api/authAPI.ts
+++ b/src/api/authAPI.ts
@@ -1,37 +1,51 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { AxiosError } from 'axios';
 
 import { customInstance } from './axios-client';
 
+interface SignupRequest {
+  email: string;
+  name: string;
+  pwd: string;
+  pwdConfirm: string;
+  phoneNumber: string;
+  terms: string;
+}
 export const login = async (email: string, pwd: string) => {
   try {
-    // 서버에 로그인 요청
     const data = await customInstance.post('/member/login', { email, pwd });
     return data; // 명시적으로 반환
   } catch (error: unknown) {
-    // AxiosError 타입인지 확인
     if (error instanceof AxiosError) {
       const errorMessage =
         error.response?.data?.message || '로그인 요청에 실패했습니다. 다시 시도해주세요.';
       throw new Error(errorMessage);
     }
-
-    // 일반적인 Error 타입인지 확인
     if (error instanceof Error) {
       throw new Error(error.message || '알 수 없는 오류가 발생했습니다.');
     }
-
-    // 예상하지 못한 에러 처리
     throw new Error('알 수 없는 오류가 발생했습니다.');
   }
 };
 
 export const logout = async () => {
   try {
-    // 서버에 로그아웃 요청
     await customInstance.post('/member/logout');
-    console.log('로그아웃 성공');
-  } catch (error) {
-    console.error('로그아웃 요청 실패:', error);
+  } catch {
     throw new Error('로그아웃 요청에 실패했습니다. 다시 시도해주세요.');
+  }
+};
+
+export const signup = async (signupRequest: SignupRequest) => {
+  try {
+    const response = await customInstance.post('/member/signup', signupRequest);
+    console.log('회원가입 서버 응답:', response);
+    return response;
+  } catch (error) {
+    console.error('회원가입 요청 실패:', error);
+    const errorMessage =
+      (error as any).response?.data?.message || '회원가입에 실패했습니다. 다시 시도해주세요.';
+    throw new Error(errorMessage);
   }
 };

--- a/src/api/profileAPI.ts
+++ b/src/api/profileAPI.ts
@@ -1,17 +1,37 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { customInstance } from './axios-client';
 
-interface FindIdRequest {
-  name: string;
-  phoneNumber: string;
-}
-
 interface FindPasswordRequest {
   email: string;
   phoneNumber: string;
 }
 
-export const findID = async ({ name, phoneNumber }: FindIdRequest) => {
+interface CheckEmailResponse {
+  isDuplicate: boolean;
+}
+
+export const checkEmail = async (email: string) => {
+  try {
+    if (!email || email.trim() === '') {
+      throw new Error('이메일을 입력해주세요.');
+    }
+    const response = await customInstance.post<CheckEmailResponse>('/member/check-id', { email });
+    if (response.data.isDuplicate) {
+      throw new Error('이미 사용 중인 이메일입니다.');
+    }
+    return response;
+  } catch (error) {
+    if (error instanceof Error) {
+      if ((error as any).response?.status === 400) {
+        throw new Error('잘못된 이메일 주소입니다.');
+      }
+      throw error;
+    }
+    throw new Error('이메일 중복 확인에 실패했습니다.');
+  }
+};
+
+export const findID = async (name: string, phoneNumber: string) => {
   try {
     const response = await customInstance.post('/member/find-id', {
       name,

--- a/src/api/smsAPI.ts
+++ b/src/api/smsAPI.ts
@@ -1,0 +1,28 @@
+import axios from 'axios';
+
+export const sendSMS = async (phone: string) => {
+  try {
+    const response = await axios.post(
+      'https://xh4zix4q5pdhkgx3gortekzesa0wpqxd.lambda-url.ap-northeast-2.on.aws/send',
+      { phone: phone }
+    );
+    console.log(response.data);
+  } catch (error) {
+    console.error('Full error:', error);
+    console.error('Error response:', (error as any).response?.data);
+  }
+};
+
+export const verifySMS = async (phone: string, token: string) => {
+  try {
+    const response = await axios.post(
+      'https://xh4zix4q5pdhkgx3gortekzesa0wpqxd.lambda-url.ap-northeast-2.on.aws/verify',
+      { phone: phone, token: token }
+    );
+    return response;
+  } catch (error) {
+    const errorMessage =
+      (error as any).response?.data?.message || '인증번호 확인에 실패했습니다. 다시 시도해주세요.';
+    throw new Error(errorMessage);
+  }
+};

--- a/src/components/custom/forms/FindAccountForm.tsx
+++ b/src/components/custom/forms/FindAccountForm.tsx
@@ -1,18 +1,20 @@
 import React, { useState } from 'react';
 
 import { findID, findPassword } from '@/api/profileAPI';
+import { sendSMS, verifySMS } from '@/api/smsAPI';
 import { ResultDialog } from '@/components/custom/dialogs/FindResultDialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-
 interface FindAccountProps {
   type: 'ID' | 'PW';
 }
 
 interface FindAccountState {
   name: string;
-  email: string;
+  email?: string;
   phone: string;
+  verificationCode: string;
+  isPhoneVerified: boolean;
 }
 
 const FindAccount: React.FC<FindAccountProps> = ({ type }) => {
@@ -20,132 +22,212 @@ const FindAccount: React.FC<FindAccountProps> = ({ type }) => {
     name: '',
     email: '',
     phone: '',
+    verificationCode: '',
+    isPhoneVerified: false,
   });
-  const [error, setError] = useState<string | null>(null);
   const [resultDialogOpen, setResultDialogOpen] = useState(false);
-  const [resultMessage, setResultMessage] = useState('');
-
+  const [resultDialogInfo, setResultDialogInfo] = useState({
+    title: '',
+    message: '',
+  });
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
+    if (name === 'phone') {
+      const numbersOnly = value.replace(/[^0-9]/g, '');
+      const trimmedNumbers = numbersOnly.slice(0, 11);
+      let formattedPhone = '';
+      if (trimmedNumbers.length <= 3) {
+        formattedPhone = trimmedNumbers;
+      } else if (trimmedNumbers.length <= 7) {
+        formattedPhone = `${trimmedNumbers.slice(0, 3)}-${trimmedNumbers.slice(3)}`;
+      } else {
+        formattedPhone = `${trimmedNumbers.slice(0, 3)}-${trimmedNumbers.slice(3, 7)}-${trimmedNumbers.slice(7)}`;
+      }
+
+      setFormData((prev) => ({
+        ...prev,
+        phone: formattedPhone,
+      }));
+      return;
+    }
+
     setFormData((prev) => ({
       ...prev,
       [name]: value,
     }));
-    setError(null);
   };
 
   const handleSubmit = async () => {
     try {
-      setError(null);
-
       if (type === 'ID') {
-        if (!formData.name || !formData.phone) {
-          throw new Error('이름과 전화번호를 모두 입력해주세요.');
-        }
-
-        const response = await findID({
-          name: formData.name,
-          phoneNumber: formData.phone,
+        const response = await findID(formData.name, formData.phone);
+        setResultDialogInfo({
+          title: '아이디 찾기 결과',
+          message: `아이디(이메일) : [ ${response.data.email} ]`,
         });
-
-        if (response.data.email) {
-          setResultMessage(`찾으시는 아이디는 [ ${response.data.email} ] 입니다.`);
-          setResultDialogOpen(true);
-        } else {
-          throw new Error(response.data?.message || '일치하는 사용자 정보를 찾을 수 없습니다.');
-        }
+        setResultDialogOpen(true);
       } else {
-        if (!formData.email || !formData.phone) {
-          throw new Error('이메일과 전화번호를 모두 입력해주세요.');
-        }
-
         const response = await findPassword({
-          email: formData.email,
+          email: formData.email!,
           phoneNumber: formData.phone,
         });
-
-        if (response.data.password) {
-          setResultMessage(`비밀번호는 [ ${response.data.password} ] 입니다.`);
-          setResultDialogOpen(true);
-        } else {
-          setError(response.data?.message || '일치하는 사용자 정보를 찾을 수 없습니다.');
-        }
+        setResultDialogInfo({
+          title: '비밀번호 찾기 결과',
+          message: `비밀번호 : [ ${response.data.password} ]`,
+        });
+        setResultDialogOpen(true);
       }
-    } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : '오류가 발생했습니다. 다시 시도해주세요.';
+    } catch (error) {
+      setResultDialogInfo({
+        title: '오류',
+        message: error instanceof Error ? error.message : '오류가 발생했습니다.',
+      });
+      setResultDialogOpen(true);
+    }
+  };
 
-      setError(errorMessage);
-      setResultDialogOpen(false);
+  const handleSMS = async () => {
+    try {
+      await sendSMS(formData.phone);
+      console.log(formData.phone);
+
+      setResultDialogInfo({
+        title: '인증번호 발송',
+        message: '인증번호가 발송되었습니다.',
+      });
+      setResultDialogOpen(true);
+    } catch (error) {
+      setResultDialogInfo({
+        title: '오류',
+        message: error instanceof Error ? error.message : '인증번호 발송에 실패했습니다.',
+      });
+      setResultDialogOpen(true);
+    }
+  };
+
+  const handleSMSConfirm = async () => {
+    try {
+      await verifySMS(formData.phone, formData.verificationCode);
+      setFormData((prev) => ({
+        ...prev,
+        isPhoneVerified: true,
+      }));
+      setResultDialogInfo({
+        title: '인증 성공',
+        message: '휴대폰 인증이 완료되었습니다.',
+      });
+      setResultDialogOpen(true);
+    } catch (error) {
+      setResultDialogInfo({
+        title: '인증 실패',
+        message: error instanceof Error ? error.message : '인증번호 확인에 실패했습니다.',
+      });
+      setResultDialogOpen(true);
     }
   };
 
   return (
-    <>
-      <div className="flex flex-col w-full max-w-[360px] gap-6">
-        <h1 className="text-3xl font-bold">{type === 'ID' ? '아이디 찾기' : '비밀번호 찾기'}</h1>
+    <div className="flex flex-col w-full max-w-[360px] gap-6">
+      <h1 className="text-3xl font-bold">{type === 'ID' ? '아이디 찾기' : '비밀번호 찾기'}</h1>
 
-        <p className="text-gray-600">
-          {type === 'ID'
-            ? '회원정보에 등록된 이름과 연락처로 아이디를 찾아보세요.'
-            : '회원정보에 등록된 아이디와 연락처로 비밀번호를 확인하세요.'}
-        </p>
+      <p className="text-gray-600">
+        {type === 'ID'
+          ? '회원정보에 등록된 연락처로 본인 확인을 진행하여 아이디를 찾아보세요.'
+          : '회원정보에 등록된 연락처로 본인 확인을 해 주시면 비밀번호를 재설정할 수 있어요.'}
+      </p>
 
-        <div className="flex flex-col gap-4">
-          {type === 'ID' ? (
-            <div>
-              <label className="text-base font-medium mb-1 block">이름</label>
-              <Input
-                variant="signin"
-                type="text"
-                name="name"
-                placeholder="홍길동"
-                value={formData.name}
-                onChange={handleInputChange}
-              />
-            </div>
-          ) : (
-            <div>
-              <label className="text-base font-medium mb-1 block">이메일 (아이디)</label>
-              <Input
-                variant="signin"
-                type="email"
-                name="email"
-                placeholder="aipark@aipark.ai"
-                value={formData.email}
-                onChange={handleInputChange}
-              />
-            </div>
-          )}
+      <div className="flex flex-col gap-4">
+        <div>
+          <label className="text-base font-medium mb-1 block">이름</label>
+          <Input
+            variant="signin"
+            type="text"
+            name="name"
+            placeholder="홍길동"
+            value={formData.name}
+            onChange={handleInputChange}
+          />
+        </div>
 
+        {type === 'PW' && (
           <div>
-            <label className="text-base font-medium mb-1 block">전화번호</label>
+            <label className="text-base font-medium mb-1 block">이메일 (아이디)</label>
             <Input
               variant="signin"
-              type="tel"
-              name="phone"
-              placeholder="010-0000-0000"
-              value={formData.phone}
+              type="email"
+              name="email"
+              placeholder="aipark@aipark.ai"
+              value={formData.email}
               onChange={handleInputChange}
             />
           </div>
-
-          {error && <p className="text-red-500 text-sm">{error}</p>}
+        )}
+        <div>
+          <label className="text-base font-medium mb-1 block">전화번호</label>
+          <div className="flex gap-2">
+            <Input
+              variant="signin"
+              name="phone"
+              className="flex-2"
+              placeholder="010-1234-5678"
+              type="tel"
+              maxLength={13}
+              value={formData.phone}
+              onChange={handleInputChange}
+            />
+            {type === 'PW' && (
+              <Button
+                variant="secondary"
+                size="md"
+                onClick={handleSMS}
+                disabled={!formData.phone || formData.phone.length < 13}
+              >
+                인증 전송
+              </Button>
+            )}
+          </div>
         </div>
-
-        <Button variant="default" size="default" onClick={handleSubmit}>
-          {type === 'ID' ? '아이디 찾기' : '비밀번호 찾기'}
-        </Button>
+        {type === 'PW' && (
+          <div>
+            <label className="text-base font-medium mb-1 block">인증 번호</label>
+            <div className="flex gap-2">
+              <Input
+                variant="signin"
+                type="text"
+                name="verificationCode"
+                placeholder="******"
+                className="flex-2"
+                value={formData.verificationCode}
+                onChange={handleInputChange}
+              />
+              <Button
+                variant="secondary"
+                size="md"
+                onClick={handleSMSConfirm}
+                disabled={!formData.verificationCode}
+              >
+                인증 확인
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
 
+      <Button
+        variant="default"
+        size="default"
+        onClick={handleSubmit}
+        disabled={!formData.name || !formData.phone || (type === 'PW' && !formData.isPhoneVerified)}
+      >
+        {type === 'ID' ? '아이디 찾기' : '비밀번호 찾기'}
+      </Button>
       <ResultDialog
         open={resultDialogOpen}
         onOpenChange={setResultDialogOpen}
-        title={type === 'ID' ? '아이디 찾기 결과' : '비밀번호 찾기 결과'}
-        message={resultMessage}
+        title={resultDialogInfo.title}
+        message={resultDialogInfo.message}
       />
-    </>
+    </div>
   );
 };
-
 export default FindAccount;

--- a/src/components/custom/forms/FindAccountForm.tsx
+++ b/src/components/custom/forms/FindAccountForm.tsx
@@ -5,6 +5,7 @@ import { sendSMS, verifySMS } from '@/api/smsAPI';
 import { ResultDialog } from '@/components/custom/dialogs/FindResultDialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { formatPhoneNumber } from '@/utils/phoneNumber';
 interface FindAccountProps {
   type: 'ID' | 'PW';
 }
@@ -33,24 +34,12 @@ const FindAccount: React.FC<FindAccountProps> = ({ type }) => {
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     if (name === 'phone') {
-      const numbersOnly = value.replace(/[^0-9]/g, '');
-      const trimmedNumbers = numbersOnly.slice(0, 11);
-      let formattedPhone = '';
-      if (trimmedNumbers.length <= 3) {
-        formattedPhone = trimmedNumbers;
-      } else if (trimmedNumbers.length <= 7) {
-        formattedPhone = `${trimmedNumbers.slice(0, 3)}-${trimmedNumbers.slice(3)}`;
-      } else {
-        formattedPhone = `${trimmedNumbers.slice(0, 3)}-${trimmedNumbers.slice(3, 7)}-${trimmedNumbers.slice(7)}`;
-      }
-
       setFormData((prev) => ({
         ...prev,
-        phone: formattedPhone,
+        phone: formatPhoneNumber(value),
       }));
       return;
     }
-
     setFormData((prev) => ({
       ...prev,
       [name]: value,

--- a/src/utils/joaatHash.ts
+++ b/src/utils/joaatHash.ts
@@ -1,0 +1,15 @@
+export function joaatHash(str: string): string {
+  let hash = 0;
+
+  for (let i = 0; i < str.length; i++) {
+    hash += str.charCodeAt(i);
+    hash += hash << 10;
+    hash ^= hash >>> 6;
+  }
+
+  hash += hash << 3;
+  hash ^= hash >>> 11;
+  hash += hash << 15;
+
+  return (hash >>> 0).toString(16);
+}

--- a/src/utils/phoneNumber.ts
+++ b/src/utils/phoneNumber.ts
@@ -1,0 +1,15 @@
+export const formatPhoneNumber = (phoneNumber: string): string => {
+  const numbersOnly = phoneNumber.replace(/[^0-9]/g, '');
+  const trimmedNumbers = numbersOnly.slice(0, 11);
+  if (trimmedNumbers.length <= 3) {
+    return trimmedNumbers;
+  } else if (trimmedNumbers.length <= 7) {
+    return `${trimmedNumbers.slice(0, 3)}-${trimmedNumbers.slice(3)}`;
+  } else {
+    return `${trimmedNumbers.slice(0, 3)}-${trimmedNumbers.slice(3, 7)}-${trimmedNumbers.slice(7)}`;
+  }
+};
+
+export const stripPhoneNumberFormatting = (phoneNumber: string): string => {
+  return phoneNumber.replace(/[^0-9]/g, '');
+};

--- a/src/utils/signupSchema.ts
+++ b/src/utils/signupSchema.ts
@@ -11,17 +11,17 @@ export const signupFormSchema = z
       .min(1, { message: SIGNUP_VALIDATION.REQUIRED.EMAIL })
       .email({ message: SIGNUP_VALIDATION.INVALID.EMAIL }),
 
-    password: z
+    pwd: z
       .string()
       .min(8, { message: SIGNUP_VALIDATION.REQUIRED.PASSWORD })
       .max(50, { message: SIGNUP_VALIDATION.PASSWORD_MAX_LENGTH })
       .regex(SIGNUP_VALIDATION_PATTERNS.PASSWORD, { message: SIGNUP_VALIDATION.INVALID.PASSWORD }),
 
-    passwordConfirm: z.string().min(1, { message: SIGNUP_VALIDATION.REQUIRED.PASSWORD }),
+    pwdConfirm: z.string().min(1, { message: SIGNUP_VALIDATION.REQUIRED.PASSWORD }),
 
     name: z.string().min(1, { message: SIGNUP_VALIDATION.REQUIRED.NAME }),
 
-    phone: z
+    phoneNumber: z
       .string()
       .min(1, { message: SIGNUP_VALIDATION.REQUIRED.PHONE })
       .regex(SIGNUP_VALIDATION_PATTERNS.PHONE, { message: SIGNUP_VALIDATION.INVALID.PHONE }),
@@ -30,7 +30,7 @@ export const signupFormSchema = z
       message: SIGNUP_VALIDATION.TERMS_REQUIRED,
     }),
   })
-  .refine((data) => data.password === data.passwordConfirm, {
+  .refine((data) => data.pwd === data.pwdConfirm, {
     message: SIGNUP_VALIDATION.PASSWORD_MISMATCH,
     path: ['passwordConfirm'],
   });
@@ -39,9 +39,9 @@ export const signupFormSchema = z
 export const SignupFormRequest = (formData: SignupFormData): SignupRequest => {
   return {
     email: formData.email,
-    pwd: formData.password,
+    pwd: formData.pwd,
     name: formData.name,
-    phone_number: formData.phone,
+    phone_number: formData.phoneNumber,
     tou: formData.terms.length === 3 ? 'Y' : 'N',
     is_deleted: false,
   };


### PR DESCRIPTION
회원가입 비밀번호 1234 입력 -> db에 해쉬값 qwer 로 변환해서 string 으로 저장.
로그인 1234 입력 -> 해쉬값 qwer 으로 변환 = db값과 매칭
임시비밀번호 체크 = 해쉬 전환 X , qwer 을 string 으로 보내서 db값과 매칭

그래서 해시적용이 안 된 기존 user1,2,3 은 임시비밀번호 사용 체크해야 합니다. 

---

aws 람다 함수로 coolsms 전화번호 인증 api 만들었으며 
포스트맨으로 람다함수 url로 { "phone" : "010-1234-1234" } 보내면 인증번호 문자 오는데
페이지에 연결하는 것은 아직 cors 에러 못 잡았습니다.
람다 url을 api 게이트웨이 설정으로 sms.popomance.kr 로 변환 작업까지 예정이고
300원 제공된 테스트 요금으로 하고 있는데, 최소 충전금액 1만원이라 충전할까... 생각중입니다.
![image](https://github.com/user-attachments/assets/eb182df5-5ff1-4892-8d6d-5b77c5c703dc)

https://console.coolsms.co.kr/dashboard
team4.popomance@gmail.com / 4whghkdlxld! 

## Sourcery에 의한 요약

계정 복구를 위한 SMS를 통한 전화번호 인증을 도입하고 안전한 저장을 위한 비밀번호 해싱을 구현합니다. 필드 처리 개선 및 임시 비밀번호 지원과 같은 추가 기능으로 회원가입 및 로그인 양식을 향상시킵니다.

새로운 기능:
- AWS Lambda를 사용하여 SMS를 통한 전화번호 인증을 구현하고 이를 계정 복구 프로세스에 통합합니다.
- 회원가입 및 로그인 시 안전한 비밀번호 저장을 위해 `joaatHash` 함수를 사용하여 비밀번호 해싱을 추가합니다.

개선 사항:
- 비밀번호 필드에 일관된 명명 규칙을 사용하고 전화번호 처리를 개선하기 위해 회원가입 양식을 리팩터링합니다.
- 로그인 양식을 개선하여 임시 비밀번호 및 이메일 기억 기능을 지원합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce phone number verification via SMS for account recovery and implement password hashing for secure storage. Enhance the signup and login forms with improved field handling and additional features like temporary password support.

New Features:
- Implement phone number verification via SMS using AWS Lambda and integrate it into the account recovery process.
- Add password hashing using the joaatHash function for secure password storage during signup and login.

Enhancements:
- Refactor the signup form to use consistent naming conventions for password fields and improve phone number handling.
- Enhance the login form to support temporary passwords and remember email functionality.

</details>