### PR TITLE
[feat] 워크스페이스-프로젝트 삭제, 최근 프로젝트 5개 api 연결 #240 #244

### DIFF
--- a/src/api/aIParkAPI.schemas.ts
+++ b/src/api/aIParkAPI.schemas.ts
@@ -272,10 +272,10 @@ export interface Project {
   projectId: number;
   projectType: string;
   projectName: string;
-  script: string;
-  projectStatus: string;
+  script?: string;
+  projectStatus?: string;
   updatedAt: string;
-  createdAt: string;
+  createdAt?: string;
 }
 
 export interface ProjectsResponse {
@@ -286,4 +286,16 @@ export interface ProjectsResponse {
   };
   totalPages: number;
   totalElements: number;
+}
+
+export interface workspacesResponse {
+  data: {
+    id: number;
+    type: string;
+    name: string;
+    script?: string;
+    status?: string;
+    updatedAt: string;
+    createdAt?: string;
+  }[];
 }

--- a/src/api/workspaceAPI.ts
+++ b/src/api/workspaceAPI.ts
@@ -5,7 +5,7 @@ export const fetchProjects = async (
   page: number,
   size: number,
   keyword: string = ''
-): Promise<{ content: Project[]; totalPages: number }> => {
+): Promise<{ content: Project[]; totalPages: number; totalElements: number }> => {
   try {
     const response = await customInstance.get('/workspace/projects', {
       params: { page, size, keyword },
@@ -16,31 +16,37 @@ export const fetchProjects = async (
     // 응답에서 data 필드 추출
     const data = response.data;
 
-    if (!data) {
-      throw new Error('API 응답 데이터가 비어 있습니다.');
-    }
-
     console.log('API 전체 응답:', response.data);
     console.log('API 부분 응답:', data);
     console.log('프로젝트 데이터:', data.content);
     console.log('총 페이지 수:', data.totalPages);
 
     // 데이터 검증
-    if (
-      !Array.isArray(data.content) || // content는 배열이어야 함
-      typeof data.totalPages !== 'number' // totalPages는 숫자여야 함
-    ) {
-      console.error('API 부분 응답:', data);
-      throw new Error('API 응답 구조가 예상과 다릅니다.');
+    if (!data || !Array.isArray(data.content) || typeof data.totalPages !== 'number') {
+      throw new Error('API 응답 데이터가 예상과 다릅니다.');
     }
 
     // 반환
     return {
       content: data.content,
       totalPages: data.totalPages,
+      totalElements: data.totalElements,
     };
   } catch (error) {
     console.error('API 요청 실패:', error);
     throw new Error('API 요청 실패');
+  }
+};
+
+export const deleteProject = async (projectIds: number[]) => {
+  try {
+    const response = await customInstance.delete('/workspace/delete/project', {
+      data: projectIds, // 요청 본문에 ID 배열 전달
+    });
+    console.log('프로젝트 삭제 성공:', response.data);
+    return response.data;
+  } catch (error) {
+    console.error('프로젝트 삭제 실패:', error);
+    throw error;
   }
 };

--- a/src/api/workspaceAPI.ts
+++ b/src/api/workspaceAPI.ts
@@ -1,4 +1,4 @@
-import { Project } from '@/api/aIParkAPI.schemas';
+import { Project, workspacesResponse } from '@/api/aIParkAPI.schemas';
 import { customInstance } from '@/api/axios-client';
 
 export const fetchProjects = async (
@@ -48,5 +48,24 @@ export const deleteProject = async (projectIds: number[]) => {
   } catch (error) {
     console.error('프로젝트 삭제 실패:', error);
     throw error;
+  }
+};
+export const fetchRecentProjects = async (): Promise<Project[]> => {
+  try {
+    const response = await customInstance.get<workspacesResponse>('/workspace/project-list');
+    console.log('최근 프로젝트 데이터:', response.data);
+
+    return response.data.data.map((project) => ({
+      projectId: project.id, // id를 projectId로 매핑
+      projectType: project.type, // type을 projectType으로 매핑
+      projectName: project.name, // name을 projectName으로 매핑
+      script: project.script || '스크립트 없음', // script 기본값 처리
+      updatedAt: project.updatedAt,
+      createdAt: project.createdAt,
+      projectStatus: project.status,
+    }));
+  } catch (error) {
+    console.error('최근 프로젝트 조회 실패:', error);
+    throw new Error('최근 프로젝트 조회에 실패했습니다.');
   }
 };

--- a/src/components/custom/cards/RecentProjectCard.tsx
+++ b/src/components/custom/cards/RecentProjectCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { TbArrowUpRight, TbPlayerPlayFilled } from 'react-icons/tb';
+import { TbArrowUpRight } from 'react-icons/tb';
 
 import RecentCardbg1 from '@/images/recent-card-bg1.svg';
 import RecentCardbg2 from '@/images/recent-card-bg2.svg';
@@ -10,12 +10,9 @@ const backgrounds = [RecentCardbg1, RecentCardbg2, RecentCardbg3, RecentCardbg4]
 
 interface RecentProjectCardProps {
   title: string;
-  description: string;
+  description?: string;
   date: string;
   type: string;
-  language: string;
-  voice: string;
-  hasPlayback: boolean;
 }
 
 const RecentProjectCard: React.FC<RecentProjectCardProps> = ({
@@ -23,9 +20,6 @@ const RecentProjectCard: React.FC<RecentProjectCardProps> = ({
   description,
   date,
   type,
-  language,
-  // voice,
-  hasPlayback,
 }) => {
   const [background, setBackground] = useState<string>('');
 
@@ -39,30 +33,17 @@ const RecentProjectCard: React.FC<RecentProjectCardProps> = ({
     <div className="w-[276px] h-[318px] flex-shrink-0 rounded-lg bg-gray-50 overflow-hidden px-6 pt-5 pb-5">
       <div className="relative h-40 overflow-hidden">
         <img src={background} className="w-full h-full object-cover" />
-        <div className="absolute top-3 left-3 flex items-center bg-white opacity-70 px-1 py-1 rounded-full gap-1">
-          {/* 보이스이미지가 없어서 원형으로 대체 */}
-          <div className="w-5 h-5 bg-gray-400 rounded-full"></div>
-          <span className="text-tiny bg-purple-50 text-purple-900 px-2 rounded-full">
-            {language}
-          </span>
-        </div>
+
         <div className="absolute bottom-0 right-0 w-10 h-10 bg-white rounded-full flex items-center justify-center cursor-pointer hover:bg-gray-100 z-10">
           <TbArrowUpRight className="text-primary" style={{ fontSize: '30px' }} />
         </div>
-
-        {/* 재생 파일이 있을 때만 가운데 재생 아이콘 표시 */}
-        {hasPlayback && (
-          <div className="absolute inset-0 flex items-center justify-center">
-            <div className="w-10 h-10 bg-white rounded-full flex items-center justify-center cursor-pointer hover:bg-gray-50">
-              <TbPlayerPlayFilled className="text-black" style={{ fontSize: '18px' }} />
-            </div>
-          </div>
-        )}
       </div>
 
       <div className="flex items-center space-x-2 mt-5 mb-3">
         <div className="text-body4 text-black px-2.5 border border-black rounded-full">{type}</div>
-        <h3 className="text-body3 text-black">{title}</h3>
+        <h3 className="text-body3 text-black truncate overflow-hidden whitespace-nowrap">
+          {title}
+        </h3>
       </div>
 
       <div>

--- a/src/components/custom/tables/history/TableToolbar.tsx
+++ b/src/components/custom/tables/history/TableToolbar.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input';
 
 interface TableToolbarProps {
   title: string;
-  count: number;
+  totalItemsCount: number;
   selectedItemsCount: number;
   onDelete: () => void;
   onSearch: (searchTerm: string) => void;
@@ -13,7 +13,7 @@ interface TableToolbarProps {
 
 const TableToolbar: React.FC<TableToolbarProps> = ({
   title,
-  count,
+  totalItemsCount,
   selectedItemsCount,
   onDelete,
   onSearch,
@@ -25,7 +25,7 @@ const TableToolbar: React.FC<TableToolbarProps> = ({
       {/* Left Section: Title and Delete Button */}
       <div className="flex items-center gap-2">
         <span className="text-body1 text-black">{title}</span>
-        <span className="text-body1 text-gray-700">{count}</span>
+        <span className="text-body1 text-gray-700">{totalItemsCount}</span>
         <button
           onClick={onDelete}
           disabled={isDeleteDisabled}

--- a/src/components/section/contents/MainContents.tsx
+++ b/src/components/section/contents/MainContents.tsx
@@ -35,6 +35,7 @@ interface MainContentsProps {
   onReorder?: (newItems: MainContentsItem[]) => void;
   currentPlayingId?: string;
   itemCount?: number;
+  totalItemsCount?: number;
   selectedItemsCount?: number;
   onSearch?: (searchTerm: string) => void;
   onFilter?: () => void;
@@ -62,6 +63,7 @@ const MainContents = ({
   onSearch,
   onFileUpload,
   hasAudioFile,
+  totalItemsCount,
 }: MainContentsProps) => {
   const getButtonText = () => `${type} 생성`;
 
@@ -71,7 +73,7 @@ const MainContents = ({
         <div className="mt-2 border rounded-md">
           <TableToolbar
             title={type === 'RECENT' ? '모든 히스토리 내역' : '모든 프로젝트'}
-            count={items.length}
+            totalItemsCount={totalItemsCount || 0}
             selectedItemsCount={selectedItemsCount || 0}
             onDelete={onDelete}
             onSearch={onSearch!}

--- a/src/components/section/contents/RecontProject.tsx
+++ b/src/components/section/contents/RecontProject.tsx
@@ -1,67 +1,32 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { TbChevronLeft, TbChevronRight } from 'react-icons/tb';
 import { useNavigate } from 'react-router-dom';
 
+import { Project } from '@/api/aIParkAPI.schemas';
+import { fetchRecentProjects } from '@/api/workspaceAPI';
 import RecentProjectCard from '@/components/custom/cards/RecentProjectCard';
-//더미 데이터
-const projects = [
-  {
-    id: 1,
-    title: '프로젝트1 발표자료',
-    description: '안녕하세요. 프로젝트1에 대한 발표를 시작해 보겠습니다.',
-    date: '금요일 오후 7:24',
-    type: 'TTS',
-    language: 'KR',
-    voice: 'Voice 1',
-    hasPlayback: true,
-  },
-  {
-    id: 2,
-    title: '프로젝트2 발표자료',
-    description: '안녕하세요. 프로젝트2에 대한 발표를 시작해 보겠습니다.',
-    date: '화요일 오후 3:15',
-    type: 'VC',
-    language: 'EN',
-    voice: 'Voice 2',
-    hasPlayback: false,
-  },
-  {
-    id: 3,
-    title: '프로젝트3 발표자료',
-    description: '안녕하세요. 프로젝트3에 대한 발표를 시작해 보겠습니다.',
-    date: '수요일 오전 11:05',
-    type: 'Concat',
-    language: 'JP',
-    voice: 'Voice 3',
-    hasPlayback: true,
-  },
-  {
-    id: 4,
-    title: '프로젝트4 발표자료',
-    description: '안녕하세요. 프로젝트4에 대한 발표를 시작해 보겠습니다.',
-    date: '목요일 오후 5:00',
-    type: 'TTS',
-    language: 'FR',
-    voice: 'Voice 4',
-    hasPlayback: false,
-  },
-  {
-    id: 5,
-    title: '프로젝트5 발표자료',
-    description: '안녕하세요. 프로젝트5에 대한 발표를 시작해 보겠습니다.',
-    date: '금요일 오후 1:30',
-    type: 'VC',
-    language: 'EN',
-    voice: 'Voice 5',
-    hasPlayback: true,
-  },
-];
+import { formatUpdatedAt } from '@/utils/dateUtils';
 
 const RecentProject = () => {
   const navigate = useNavigate();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [projects, setProjects] = useState<Project[]>([]);
   const [isScrolledLeft, setIsScrolledLeft] = useState(false);
-  const [isScrolledRight, setIsScrolledRight] = useState(projects.length > 4);
+  const [isScrolledRight, setIsScrolledRight] = useState(false);
+
+  useEffect(() => {
+    const loadRecentProjects = async () => {
+      try {
+        const data = await fetchRecentProjects();
+        setProjects(data);
+        setIsScrolledRight(data.length > 4);
+      } catch (error) {
+        console.error('최근 프로젝트 데이터를 불러오는 중 오류 발생:', error);
+      }
+    };
+
+    loadRecentProjects();
+  }, []);
 
   const handleScroll = () => {
     if (scrollContainerRef.current) {
@@ -108,16 +73,13 @@ const RecentProject = () => {
           onScroll={handleScroll}
           className="flex gap-6 overflow-x-hidden snap-x snap-mandatory scrollbar-hide scroll-smooth"
         >
-          {projects.map((project, _index) => (
-            <div key={project.id} className="snap-start">
+          {projects.map((project) => (
+            <div key={project.projectId} className="snap-start">
               <RecentProjectCard
-                title={project.title}
-                description={project.description}
-                date={project.date}
-                type={project.type}
-                language={project.language}
-                voice={project.voice}
-                hasPlayback={project.hasPlayback}
+                title={project.projectName}
+                description={project.script}
+                date={formatUpdatedAt(project.updatedAt)}
+                type={project.projectType}
               />
             </div>
           ))}

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { Project } from '@/api/aIParkAPI.schemas';
-import { fetchProjects } from '@/api/workspaceAPI';
+import { deleteProject, fetchProjects } from '@/api/workspaceAPI';
 import MainContents from '@/components/section/contents/MainContents';
 import Title from '@/components/section/contents/Title';
 import PaginationFooter from '@/components/section/footer/PaginationFooter';
@@ -13,6 +13,7 @@ const ProjectPage = () => {
   const [projects, setProjects] = useState<Project[]>([]);
   const [currentPage, setCurrentPage] = useState(0);
   const [totalPages, setTotalPages] = useState(1);
+  const [totalItemsCount, setTotalItemsCount] = useState(0);
 
   const [selectedItems, setSelectedItems] = useState<number[]>([]); // 선택된 항목
   const [searchKeyword, setSearchKeyword] = useState(''); // 검색 키워드 상태
@@ -21,10 +22,11 @@ const ProjectPage = () => {
   const loadProjects = useCallback(
     async (page: number) => {
       try {
-        const { content, totalPages } = await fetchProjects(page, 8, searchKeyword);
+        const { content, totalPages, totalElements } = await fetchProjects(page, 8, searchKeyword);
         console.log('로드된 프로젝트 데이터:', content);
         setProjects(content); // 프로젝트 데이터 설정
         setTotalPages(totalPages); // 총 페이지 수 설정
+        setTotalItemsCount(totalElements); // 전체 항목 수 설정
       } catch (error) {
         console.error('프로젝트 데이터를 불러오는 중 오류 발생:', error);
       }
@@ -44,9 +46,17 @@ const ProjectPage = () => {
     console.log(`${id} 재생 중지`);
   };
 
-  const handleDelete = () => {
-    console.log('선택된 항목 삭제');
-    // 삭제 로직
+  const handleDelete = async () => {
+    try {
+      await deleteProject(selectedItems); // 선택된 항목 삭제
+      alert('삭제되었습니다.');
+
+      // 현재 페이지 데이터 재로드
+      loadProjects(currentPage);
+    } catch (error) {
+      console.error('삭제 중 오류:', error); // 에러 로그 출력
+      alert('삭제 중 오류가 발생했습니다.');
+    }
   };
 
   const handleSearch = (searchTerm: string) => {
@@ -107,6 +117,7 @@ const ProjectPage = () => {
         itemCount={projects.length}
         selectedItemsCount={selectedItems.length}
         onSearch={handleSearch}
+        totalItemsCount={totalItemsCount}
       />
     </PageLayout>
   );


### PR DESCRIPTION
<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- 수정된 화면이나 기능을 보여주는 스크린샷을 첨부할 수 있습니다. -->

<img width="708" alt="스크린샷 2024-12-03 오후 12 56 31" src="https://github.com/user-attachments/assets/5c920a7a-67f2-4ea2-b572-b705b110dfea">

최근 프로젝트에서 스크립트 없음으로 나오는데 백엔드에서 응답값에 안 넣어놓은 상태라서 추후 백엔드에서 업데이트 해주면 스크립트도 잘 보일걸로 예상됩니다

## Sourcery에 의한 요약

최근 프로젝트를 가져오고 표시하기 위한 API 통합, 동적 데이터를 사용하도록 구성 요소 리팩토링, 프로젝트 삭제 기능 구현.

새로운 기능:
- 워크스페이스에서 가장 최근의 다섯 개 프로젝트를 가져오고 표시하기 위한 API 통합 구현.

개선 사항:
- 하드코딩된 더미 데이터를 사용하는 대신 API에서 프로젝트 데이터를 동적으로 로드하도록 RecentProject 구성 요소 리팩토링.
- 선택적 설명을 처리하고 언어 및 음성과 같은 사용되지 않는 속성을 제거하도록 RecentProjectCard 구성 요소 업데이트.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate API to fetch and display recent projects, refactor components to use dynamic data, and implement project deletion functionality.

New Features:
- Implement API integration to fetch and display the five most recent projects in the workspace.

Enhancements:
- Refactor the RecentProject component to dynamically load project data from the API instead of using hardcoded dummy data.
- Update the RecentProjectCard component to handle optional description and remove unused properties like language and voice.

</details>