### PR TITLE
[bug] 로그인 후 새로고침하면 유저 정보 날라가는 버그 #248

### DIFF
--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -3,16 +3,15 @@ import { persist } from 'zustand/middleware';
 
 interface User {
   id: number;
-  email?: string;
-  name?: string;
-  phoneNumber?: string;
+  email: string;
+  name: string;
+  phoneNumber: string;
 }
 
 interface AuthState {
   user: User | null;
   setUser: (user: User) => void;
   logout: () => void;
-  fetchUser: () => Promise<void>; // 서버에서 사용자 정보 가져오기
 }
 
 export const useAuthStore = create<AuthState>()(
@@ -21,24 +20,10 @@ export const useAuthStore = create<AuthState>()(
       user: null,
       setUser: (user) => set({ user }),
       logout: () => set({ user: null }),
-      fetchUser: async () => {
-        const id = JSON.parse(localStorage.getItem('auth-storage') || '{}').user?.id;
-        if (id) {
-          try {
-            const response = await fetch(`/api/user/${id}`);
-            const userData = await response.json();
-            set({ user: userData });
-          } catch (error) {
-            console.error('Failed to fetch user:', error);
-          }
-        }
-      },
     }),
     {
-      name: 'auth-storage', // 로컬스토리지에 id만 저장
-      partialize: (state) => ({
-        user: state.user ? { id: state.user.id } : null, // id만 저장
-      }),
+      name: 'auth-storage', // localStorage 키 이름
+      partialize: (state) => ({ user: state.user }), // user 정보만 저장
     }
   )
 );


### PR DESCRIPTION
<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- 수정된 화면이나 기능을 보여주는 스크린샷을 첨부할 수 있습니다. -->


로컬스토리지에 id만 넣어두니 새로고침하면 사용자 정보가 계속 날라갑니다
멘토님께서 id만 넣는거랑 유저 정보 다 넣는거랑 크게 다를 게 없을것 같다고 하셨습니다
빠른 해결을 위해 그냥 user정보 로컬스토리지에 다 넣는걸로 원복합니다

## Sourcery에 의한 요약

버그 수정:
- 사용자 ID만 저장하는 대신 전체 사용자 데이터를 로컬 스토리지에 저장하여 페이지 새로 고침 시 사용자 정보 손실 문제를 수정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix user information loss on page refresh by storing complete user data in local storage instead of just the user ID.

</details>