### PR TITLE
[fix] tts 테이블에서 enter 눌렀을 때 새줄 추가

### DIFF
--- a/src/components/custom/tables/project/tts/SortableGridItem.tsx
+++ b/src/components/custom/tables/project/tts/SortableGridItem.tsx
@@ -13,6 +13,7 @@ import TooltipWrapper from '@/components/custom/guide/TooltipWrapper';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Textarea } from '@/components/ui/textarea';
 import { TTS_TOOLTIP } from '@/constants/tooltips';
+import { useTTSStore } from '@/stores/tts.store';
 import { useAudioHistoryStore } from '@/stores/ttsPlayback.store.ts';
 
 import TTSPlaybackHistory from './TTSPlaybackHistory';
@@ -41,8 +42,7 @@ export const SortableGridItem = memo((props: SortableGridItemProps) => {
   const handleDelete = useAudioHistoryStore((state) => state.deleteHistoryItem)(props.id);
   const [isHistoryOpen, setIsHistoryOpen] = useState(false);
 
-  console.log('props.id', props.id);
-  console.log('isHistoryOpen', isHistoryOpen);
+  const addItems = useTTSStore((state) => state.addItems);
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -140,6 +140,18 @@ export const SortableGridItem = memo((props: SortableGridItemProps) => {
             placeholder="스크립트를 입력하세요."
             className="w-3/5 min-h-[40px] overflow-hidden mb-2 border-0"
             rows={1}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                addItems();
+                setTimeout(() => {
+                  const textareas = document.querySelectorAll('textarea');
+                  if (textareas.length > 0) {
+                    textareas[textareas.length - 1].focus();
+                  }
+                }, 0);
+              }
+            }}
           />
           <div className="w-3/5 mb-5">
             <AudioPlayer audioUrl={props.audioUrl} className="px-6 py-3" />

--- a/src/components/custom/tables/project/tts/TTSListRow.tsx
+++ b/src/components/custom/tables/project/tts/TTSListRow.tsx
@@ -9,6 +9,7 @@ import TTSPlaybackHistory from '@/components/custom/tables/project/tts/TTSPlayba
 import { Checkbox } from '@/components/ui/checkbox';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
+import { useTTSStore } from '@/stores/tts.store';
 import { useAudioHistoryStore } from '@/stores/ttsPlayback.store.ts';
 import { ListRowProps } from '@/types/table';
 
@@ -43,6 +44,8 @@ export const TTSListRow: React.FC<ListRowProps> = ({
     element.style.height = `${element.scrollHeight}px`;
   };
 
+  const addItems = useTTSStore((state) => state.addItems);
+
   useEffect(() => {
     const textareas = document.querySelectorAll('textarea');
     textareas.forEach((textarea) => {
@@ -69,6 +72,18 @@ export const TTSListRow: React.FC<ListRowProps> = ({
           onChange={(e) => {
             onTextChange(id, e.target.value);
             handleTextAreaResize(e.target);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              addItems();
+              setTimeout(() => {
+                const textareas = document.querySelectorAll('textarea');
+                if (textareas.length > 0) {
+                  textareas[textareas.length - 1].focus();
+                }
+              }, 0);
+            }
           }}
           onInput={(e) => handleTextAreaResize(e.currentTarget)}
           placeholder="텍스트를 입력하세요."


### PR DESCRIPTION
- tts 테이블에서 텍스트 에어리어에서 enter 누르면 새줄이 추가되도록 수정.

- shift enter 누르면 새줄 추가 안됨. 


<!-- 주요 변경 사항을 요약해 주세요. -->

<!-- 수정된 화면이나 기능을 보여주는 스크린샷을 첨부할 수 있습니다. -->

## Sourcery에 의한 요약

버그 수정:
- Shift+Enter가 사용되지 않을 때 Enter 키를 누르면 TTS 테이블의 텍스트 영역에 새 줄이 추가되도록 동작을 수정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the behavior of the text area in the TTS table to add a new line when the Enter key is pressed, except when Shift+Enter is used.

</details>